### PR TITLE
JAX implementations of Flat wCDM cosmology functions

### DIFF
--- a/dsps/flat_wcdm.py
+++ b/dsps/flat_wcdm.py
@@ -1,0 +1,118 @@
+"""
+"""
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+c_speed = 2.99792458e8  # m/s
+
+# rho_crit(z=0) in [Msun * h^2 * kpc^-3]
+RHO_CRIT0_KPC3_UNITY_H = 277.536627  # multiply by h**2 in cosmology conversion
+
+MPC = 3.08567758149e24  # Mpc in cm
+YEAR = 31556925.2  # year in seconds
+
+
+@jjit
+def _rho_de_z(z, w0, wa):
+    a = 1.0 / (1.0 + z)
+    de_z = a ** (-3.0 * (1.0 + w0 + wa)) * jnp.exp(-3.0 * wa * (1.0 - a))
+    return de_z
+
+
+@jjit
+def _Ez(z, Om0, Ode0, w0, wa):
+    zp1 = 1.0 + z
+    t = Om0 * zp1 ** 3 + Ode0 * _rho_de_z(z, w0, wa)
+    E = jnp.sqrt(t)
+    return E
+
+
+@jjit
+def _integrand_oneOverEz(z, Om0, Ode0, w0, wa):
+    return 1 / _Ez(z, Om0, Ode0, w0, wa)
+
+
+@jjit
+def _integrand_oneOverEz1pz(z, Om0, Ode0, w0, wa):
+    return 1.0 / _Ez(z, Om0, Ode0, w0, wa) / (1.0 + z)
+
+
+@jjit
+def _comoving_distance_to_z(z, Om0, Ode0, w0, wa, h):
+    z_table = jnp.linspace(0, z, 256)
+    integrand = _integrand_oneOverEz(z_table, Om0, Ode0, w0, wa)
+    # The 1E-5 factor comes from the conversion between the
+    # speed of light in m/s to km/s and H0 = 100 * h.
+    return jnp.trapz(integrand, x=z_table) * c_speed * 1e-5 / h
+
+
+@jjit
+def _luminosity_distance_to_z(z, Om0, Ode0, w0, wa, h):
+    return _comoving_distance_to_z(z, Om0, Ode0, w0, wa, h) * (1 + z)
+
+
+@jjit
+def _angular_diameter_distance_to_z(z, Om0, Ode0, w0, wa, h):
+    return _comoving_distance_to_z(z, Om0, Ode0, w0, wa, h) / (1 + z)
+
+
+@jjit
+def _distance_modulus_to_z(z, Om0, Ode0, w0, wa, h):
+    d_lum = _luminosity_distance_to_z(z, Om0, Ode0, w0, wa, h)
+    mu = 5.0 * jnp.log10(d_lum * 1e5)
+    return mu
+
+
+@jjit
+def _hubble_time(z, Om0, Ode0, w0, wa, h):
+    E0 = _Ez(z, Om0, Ode0, w0, wa)
+    htime = 1e-16 * MPC / YEAR / h / E0
+    return htime
+
+
+@jjit
+def _lookback_to_z(z, Om0, Ode0, w0, wa, h):
+    z_table = jnp.linspace(0, z, 256)
+    integrand = 1 / _Ez(z_table, Om0, Ode0, w0, wa) / (1 + z_table)
+    res = jnp.trapz(integrand, x=z_table)
+    th = _hubble_time(0.0, Om0, Ode0, w0, wa, h)
+    return th * res
+
+
+@jjit
+def _rho_crit(z, Om0, Ode0, w0, wa, h):
+    """Critical density in units of physical Msun/kpc**3"""
+    rho_crit0 = RHO_CRIT0_KPC3_UNITY_H * h * h
+    return rho_crit0 * _Ez(z, Om0, Ode0, w0, wa) ** 2
+
+
+@jjit
+def _Om_at_z(z, Om0, Ode0, w0, wa):
+    E = _Ez(z, Om0, Ode0, w0, wa)
+    return Om0 * (1.0 + z) ** 3 / E / E
+
+
+_A = (0, *[None] * 5)
+_distance_modulus = jjit(vmap(_distance_modulus_to_z, in_axes=_A))
+_luminosity_distance = jjit(vmap(_luminosity_distance_to_z, in_axes=_A))
+_angular_diameter_distance = jjit(vmap(_angular_diameter_distance_to_z, in_axes=_A))
+_lookback_time = jjit(vmap(_lookback_to_z, in_axes=_A))
+_Om = jjit(vmap(_Om_at_z, in_axes=_A[:-1]))
+
+
+@jjit
+def _delta_vir(z, Om0, Ode0, w0, wa):
+    x = _Om(z, Om0, Ode0, w0, wa) - 1.0
+    Delta = 18 * jnp.pi ** 2 + 82.0 * x - 39.0 * x ** 2
+    return Delta
+
+
+@jjit
+def _virial_dynamical_time(z, Om0, Ode0, w0, wa, h):
+    """Dynamical time to cross the diameter of a halo at redshift z.
+    The pericentric passage time is half this time.
+    The orbital time is PI times this time."""
+    delta = _delta_vir(z, Om0, Ode0, w0, wa)
+    t_cross = 2 ** 1.5 * _hubble_time(z, Om0, Ode0, w0, wa, h) * delta ** -0.5
+    return t_cross

--- a/dsps/tests/test_flat_wcdm.py
+++ b/dsps/tests/test_flat_wcdm.py
@@ -1,0 +1,86 @@
+"""
+"""
+import numpy as np
+from ..flat_wcdm import _distance_modulus, _angular_diameter_distance
+from ..flat_wcdm import _lookback_time, _Om, _delta_vir, _virial_dynamical_time
+
+try:
+    from astropy.cosmology import Planck15, WMAP5, Flatw0waCDM
+
+    LCDM_COSMO_LIST = Planck15, WMAP5
+except ImportError:
+    LCDM_COSMO_LIST = []
+
+
+def test_flat_lcdm():
+    zray = np.linspace(0.001, 10, 500)
+    for cosmo in LCDM_COSMO_LIST:
+        params = cosmo.Om0, cosmo.Ode0, -1.0, 0.0, cosmo.h
+
+        dmod_astropy = cosmo.distmod(zray).value
+        dmod_jax = _distance_modulus(zray, *params)
+        assert np.allclose(dmod_astropy, dmod_jax, rtol=0.001)
+
+        angdist_astropy = cosmo.angular_diameter_distance(zray).value
+        angdist_jax = _angular_diameter_distance(zray, *params)
+        assert np.allclose(angdist_astropy, angdist_jax, rtol=0.005)
+
+        lookback_astropy = cosmo.lookback_time(zray).value
+        lookback_jax = _lookback_time(zray, *params)
+        assert np.allclose(lookback_astropy, lookback_jax, rtol=0.005)
+
+        om_astropy = cosmo.Om(zray)
+        om_jax = _Om(zray, *params[:-1])
+        assert np.allclose(om_astropy, om_jax, rtol=0.01)
+
+
+def test_flat_wcdm_distances():
+    n_test = 10
+    zray = np.linspace(0.001, 10, 50)
+    for lcdm_cosmo in LCDM_COSMO_LIST:
+        for itest in range(n_test):
+            w0 = np.random.uniform(-1.5, -0.5)
+            wa = np.random.uniform(-0.5, 0.5)
+            w_cosmo = Flatw0waCDM(lcdm_cosmo.H0, lcdm_cosmo.Om0, w0=w0, wa=wa)
+            params = w_cosmo.Om0, w_cosmo.Ode0, w0, wa, w_cosmo.h
+
+            dmod_astropy = w_cosmo.distmod(zray).value
+            dmod_jax = _distance_modulus(zray, *params)
+            assert np.allclose(dmod_astropy, dmod_jax, rtol=0.001)
+
+            angdist_astropy = w_cosmo.angular_diameter_distance(zray).value
+            angdist_jax = _angular_diameter_distance(zray, *params)
+            assert np.allclose(angdist_astropy, angdist_jax, rtol=0.001)
+
+            lookback_astropy = w_cosmo.lookback_time(zray).value
+            lookback_jax = _lookback_time(zray, *params)
+            assert np.allclose(lookback_astropy, lookback_jax, rtol=0.001)
+
+            om_astropy = w_cosmo.Om(zray)
+            om_jax = _Om(zray, *params[:-1])
+            assert np.allclose(om_astropy, om_jax, rtol=0.001)
+
+
+def test_delta_vir():
+    """Enforce delta~178 at high-z and monotonically decreases thereafter"""
+    zray = np.linspace(0.001, 10, 50)
+    for cosmo in LCDM_COSMO_LIST:
+        params = cosmo.Om0, cosmo.Ode0, -1.0, 0.0, cosmo.h
+        z_high = np.atleast_1d(500.0)
+        delta = float(_delta_vir(z_high, *params[:-1]))
+        assert np.allclose(delta, 178, atol=1)
+        delta_ray = _delta_vir(zray, *params[:-1])
+        assert np.all(np.diff(delta_ray) > 0)
+
+
+def test_dynamical_time():
+    """Enforce dynamical times increase as dark energy becomes operative"""
+    zray = np.linspace(0.001, 10, 50)
+    for cosmo in LCDM_COSMO_LIST:
+        params = cosmo.Om0, cosmo.Ode0, -1.0, 0.0, cosmo.h
+        tcross = _virial_dynamical_time(zray, *params)
+        assert np.all(np.diff(tcross) < 0)
+
+        z0 = np.atleast_1d(0.0)
+        tcross_z0 = float(_virial_dynamical_time(z0, *params))
+        assert np.allclose(tcross_z0, 4, atol=1)


### PR DESCRIPTION
This PR brings in differentiable implementations of a few basic cosmology functions needed by DSPS, plus a little other low-hanging fruit:
1. Luminosity distance, D_L(z, θ)
2. Distance modulus, m(z, θ)
3. Lookback time τ_look(z, θ)
4. Angular diameter distance, D_A(z, θ)
5. ρ_crit(z, θ)
6. Halo dynamical time, τ_dyn(z, θ)

In these functions, the parameter `θ = {Ω_m, Ω_Λ, w_0, w_a, h}`, and I only implemented flat geometries. The unit-testing validates accuracy to ~0.1% using either Astropy or colossus. Here are a couple of simple validation plots. 
![cosmojax_lookback](https://user-images.githubusercontent.com/6951595/139705583-b2d783ef-941b-4f2e-94cf-28ee08e9a8f9.png)
![cosmojax_distance_modulus](https://user-images.githubusercontent.com/6951595/139705594-d0db1c32-b19b-43f0-8ef3-19b8fcd140a1.png)


