### PR TITLE
Updated metallicity evolution model

### DIFF
--- a/dsps/tests/test_mzr.py
+++ b/dsps/tests/test_mzr.py
@@ -1,8 +1,11 @@
 """
 """
 import numpy as np
-from ..mzr import _get_met_weights_singlegal
+from ..mzr import _get_met_weights_singlegal, MAIOLINO08_PARAMS
+from ..mzr import MZR_VS_T_PARAMS, mzr_evolution_model
+from ..mzr import maiolino08_metallicity_evolution as m08_zevol
 from ..utils import _get_bin_edges
+from astropy.cosmology import Planck15
 
 
 def test_get_met_weights():
@@ -22,3 +25,16 @@ def test_get_met_weights():
 
     weights = _get_met_weights_singlegal(lgz, lgz_scatter, lgzsunbins)
     assert weights.shape == (n_bins,)
+
+
+def test_mzr_fit_agreement_with_maiolino08():
+    ztest = np.array(list(MAIOLINO08_PARAMS.keys())[1:-1])
+    cosmic_time = Planck15.age(ztest).value
+    lgsmarr_fit = np.linspace(9, 11, 50)
+    m08_at_z0 = m08_zevol(lgsmarr_fit, *MAIOLINO08_PARAMS[0.07])
+
+    for i, t in enumerate(cosmic_time):
+        logZ_reduction = mzr_evolution_model(lgsmarr_fit, t, *MZR_VS_T_PARAMS.values())
+        m08_at_z = m08_zevol(lgsmarr_fit, *MAIOLINO08_PARAMS[ztest[i]])
+        logZ_reduction_correct = m08_at_z - m08_at_z0
+        assert np.allclose(logZ_reduction, logZ_reduction_correct, atol=0.02)


### PR DESCRIPTION
The mzr.py module contains two different fitting functions used to approximate Figure 8 of [Maiolino+08](https://arxiv.org/abs/0806.2410). The first fitting function is just a reimplementation of Equation 2 taken directly from Maiolino+08:

`12 + log(O/H) = −0.0864 (logMstar − logM0)^2 + k`

The Maiolino+08 paper provides values for `logM0` and `k` for 3 particular values of redshift, `z=0.7, 2.2, 3.5`, and shows that this gives a good description of the data plotted in Figure 8 over the range of stellar masses relevant to the measurement `9 < logMstar < 11`. In DSPS we're using this fitting function (enforced by a newly-implemented unit-test brought in with this PR) to validate our own model(s) for the mass-metallicity relation (MZR).

In order to make SED predictions , we need a model for the smooth MZR evolution across redshift, not just tabulated values at a few redshifts. This PR brings in a new calibration of such a model that resolves some non-monotonic behavior at `logMstar>11` that is presumably unphysical. The first figure below displays the old vs. new smooth model that implements the fix at high mass, and the second figure shows that the improved model retains the same level of success as the previous model. 

![updated_mzr_model](https://user-images.githubusercontent.com/6951595/139750236-472f72aa-3051-4d54-bded-85a0e1fc57ae.png)
![metallicity_vs_mass_redshift_model](https://user-images.githubusercontent.com/6951595/139750341-4b185839-1a18-49ae-ab81-ef9d618e8f01.png)


