### PR TITLE
Use new jax syntax for array index updates

### DIFF
--- a/dsps/mzr.py
+++ b/dsps/mzr.py
@@ -3,7 +3,6 @@
 from collections import OrderedDict
 from jax import jit as jjit
 from jax import numpy as jnp
-from jax import ops as jops
 from jax import vmap
 from .utils import triweighted_histogram, _get_bin_edges, _tw_sigmoid
 
@@ -189,8 +188,8 @@ def _fill_empty_weights_singlegal(lgmet, lgmetbin_edges, weights):
     lores = jnp.zeros(lgmetbin_edges.size - 1)
     hires = jnp.zeros(lgmetbin_edges.size - 1)
 
-    lores = jops.index_update(lores, jops.index[0], 1.0)
-    hires = jops.index_update(hires, jops.index[-1], 1.0)
+    lores = lores.at[0].set(1.0)
+    hires = hires.at[-1].set(1.0)
 
     weights = jnp.where(zmsk & lomsk, lores, weights)
     weights = jnp.where(zmsk & himsk, hires, weights)
@@ -222,7 +221,7 @@ def calc_lgmet_weights_from_logsm_table(
     lgmet_scatter = met_params[-1]
 
     logsm_at_t_obs = jnp.interp(lgt_obs, lgt_table, logsm_table)
-    lgmet = mzr_model(logsm_at_t_obs, 10 ** lgt_obs, *met_params[:-1])
+    lgmet = mzr_model(logsm_at_t_obs, 10**lgt_obs, *met_params[:-1])
     lgmet_weights = _get_met_weights_singlegal(lgmet, lgmet_scatter, lgmet_bin_edges)
     return lgmet_weights
 

--- a/dsps/stellar_ages.py
+++ b/dsps/stellar_ages.py
@@ -2,7 +2,6 @@
 """
 from jax import numpy as jnp
 from jax import jit as jjit
-from jax import ops as jops
 from .utils import _jax_get_dt_array
 from .sfh_model import diffstar_sfh, TODAY
 
@@ -29,7 +28,7 @@ def _get_sfh_tables(mah_params, ms_params, q_params):
 
 @jjit
 def _get_lgt_birth(t_obs, lg_ages):
-    t_birth = t_obs - 10 ** lg_ages
+    t_birth = t_obs - 10**lg_ages
     t_birth = jnp.where(t_birth < T_BIRTH_MIN, T_BIRTH_MIN, t_birth)
     lgt_birth = jnp.log10(t_birth)
     return lgt_birth
@@ -38,7 +37,7 @@ def _get_lgt_birth(t_obs, lg_ages):
 @jjit
 def _get_age_weights_from_tables(lgt_birth_bin_edges, lgt_table, logsm_table):
     logsm_at_t_birth_bin_edges = jnp.interp(lgt_birth_bin_edges, lgt_table, logsm_table)
-    delta_mstar_at_t_birth = -jnp.diff(10 ** logsm_at_t_birth_bin_edges)
+    delta_mstar_at_t_birth = -jnp.diff(10**logsm_at_t_birth_bin_edges)
     age_weights = delta_mstar_at_t_birth / delta_mstar_at_t_birth.sum()
     return age_weights
 
@@ -70,14 +69,12 @@ def _get_lg_age_bin_edges(lg_ages):
     dlgtau = _jax_get_dt_array(lg_ages)
 
     lg_age_bin_edges = jnp.zeros(dlgtau.size + 1)
-    lg_age_bin_edges = jops.index_update(
-        lg_age_bin_edges, jops.index[:-1], lg_ages - dlgtau / 2
-    )
+    lg_age_bin_edges = lg_age_bin_edges.at[:-1].set(lg_ages - dlgtau / 2)
 
     dlowest = (lg_ages[1] - lg_ages[0]) / 2
     lowest = lg_ages[0] - dlowest
     highest = lg_ages[-1] + dlgtau[-1] / 2
-    lg_age_bin_edges = jops.index_update(lg_age_bin_edges, jops.index[0], lowest)
-    lg_age_bin_edges = jops.index_update(lg_age_bin_edges, jops.index[-1], highest)
+    lg_age_bin_edges = lg_age_bin_edges.at[0].set(lowest)
+    lg_age_bin_edges = lg_age_bin_edges.at[-1].set(highest)
 
     return lg_age_bin_edges


### PR DESCRIPTION
This PR replaces the deprecated use of jax.ops.index_update with the new preferred syntax