### PR TITLE
NaN-safe k_ λ attenuation curve

### DIFF
--- a/dsps/tests/test_attenuation.py
+++ b/dsps/tests/test_attenuation.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 from ..attenuation_kernels import RV_C00, calzetti00_k_lambda, leitherer02_k_lambda
 from ..attenuation_kernels import noll09_k_lambda, _attenuation_curve, sbl18_k_lambda
-
+from ..attenuation_kernels import triweight_k_lambda, _l02_below_c00_above
 
 _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 TEST_DRN = os.path.join(_THIS_DRNAME, "testing_data")
@@ -70,6 +70,13 @@ def test_salim18():
         attenuation = np.loadtxt(afn)
         attenuation2 = _attenuation_curve(k2, RV_C00, av)
         assert np.allclose(attenuation, attenuation2)
+
+
+def test_triweight_k_lambda():
+    x_microns_target = np.linspace(0.097, 2.2, 100)
+    noll09_target = _l02_below_c00_above(x_microns_target)
+    tw_approx = triweight_k_lambda(x_microns_target)
+    assert np.allclose(noll09_target, tw_approx, rtol=0.1)
 
 
 def _read_noll09_header(fn):

--- a/dsps/utils.py
+++ b/dsps/utils.py
@@ -115,6 +115,12 @@ def triweight_gaussian(x, m, h):
 
 
 @jjit
+def _tw_sig_slope(x, xtp, ytp, x0, tw_h, lo, hi):
+    slope = _tw_sigmoid(x, x0, tw_h, lo, hi)
+    return ytp + slope * (x - xtp)
+
+
+@jjit
 def interpolate_transmission_curve(wave, trans, n_out, pcut_lo=0, pcut_hi=1):
     """ """
     lowest_bin_edge = wave[0] - (wave[1] - wave[0]) / 2


### PR DESCRIPTION
New **triweight_k_lambda** function approximates the Noll+09 attenuation curve, but has better asymptotic behavior when extrapolating beyond the range where the Noll+09 curves were calibrated.

The attenuation curve `A(λ)` defines a multiplier `F_att(λ)` of the intrinsic flux `L_true(λ)` to produce the observed flux: 

$$A(\lambda) = A_{V}\cdot k_{\lambda}$$

$$F_{\rm att}(\lambda) = 10^{-0.4\cdot A(\lambda)}$$

$$L_{\rm obs}(\lambda)=F_{\rm att}(\lambda)\cdot L_{\rm true}(\lambda)$$

Many common attenuation curves are defined in terms of the [Calzetti](https://github.com/ArgonneCPAC/dsps/blob/9a80fdc89944786ae11e8d63ee13caa91e207895/dsps/attenuation_kernels.py#L50) `k_lambda` function, which is a polynomial function of 1/λ that blows up at short wavelengths. There are other forms implemented in the [attenuation_kernels.py](https://github.com/ArgonneCPAC/dsps/blob/9a80fdc89944786ae11e8d63ee13caa91e207895/dsps/attenuation_kernels.py) module, such as [Leitherer+02](https://github.com/ArgonneCPAC/dsps/blob/9a80fdc89944786ae11e8d63ee13caa91e207895/dsps/attenuation_kernels.py#L74). The [Noll+09](https://github.com/ArgonneCPAC/dsps/blob/9a80fdc89944786ae11e8d63ee13caa91e207895/dsps/attenuation_kernels.py#L107) `k_lambda` function adopts Calzetti above 0.15 microns and Leitherer+2002 below. These functions have uncontrolled asymptotic behavior, which can introduce unwanted NaNs and infinities when extrapolating beyond the range in λ where there are observational constraints. Also, these `k_lambda` functions implement λ-dependence with hard-edged clips in wavelength, which also introduces NaNs and infinities in gradients. 
 
When varying the parameters of the attenuation curve during SED fitting, the above `k_lambda` functions are typically held fixed, and some parametrized power-law multiplies the `k_lambda` function, e.g.:

$$A(\lambda) = A_{V}\cdot k_{\lambda}\cdot (\lambda / \lambda_0)^{\delta}$$

In this way, uncertainty in the "true" function `k_lambda` gets absorbed into the freely-varied parameters. This means that for most applications, any baseline `k_lambda` function we choose that's in the ballpark should be fine, since residual errors will be absorbed into the parameters that modify the baseline.

This PR brings in a new attenuation curve that is a smooth triweight-based approximation to Noll+09. The advantage of this alternative is that it is everywhere-differentiable and asymptotically well-behaved. 

The figure below shows the new `k_lambda` function; the gray shaded region shows the range where the curves are observationally constrained.
![dsps_k_lambda](https://user-images.githubusercontent.com/6951595/226749255-64cd7333-5842-4dc6-9b0f-4604f7a28264.png)

The figure below shows how the attenuation curves above translate into flux-reduction fractions.
![dsps_fatt_lambda](https://user-images.githubusercontent.com/6951595/226749281-7521e3d0-a4fd-4b17-ba24-7b1f4b8ffff4.png)

