### PR TITLE
Add support for Lower+22 attenuation curve flexibility

### DIFF
--- a/dsps/attenuation_kernels.py
+++ b/dsps/attenuation_kernels.py
@@ -13,8 +13,10 @@ N09_SLOPE_MAX = 3.0
 
 
 @jjit
-def _flux_ratio(axEbv, rv, av):
-    return 10 ** (-0.4 * _attenuation_curve(axEbv, rv, av))
+def _flux_ratio(axEbv, rv, av, frac_unobscured=0.0):
+    frac_att_obs = 10 ** (-0.4 * _attenuation_curve(axEbv, rv, av))
+    frac_att = frac_unobscured + (1 - frac_unobscured) * frac_att_obs
+    return frac_att
 
 
 @jjit


### PR DESCRIPTION
Add optional argument to _flux_ratio function to support [Lower+22](https://arxiv.org/abs/2203.00074) attenuation