### PR TITLE
Add diffburst module

### DIFF
--- a/dsps/ssp/diffburst.py
+++ b/dsps/ssp/diffburst.py
@@ -1,0 +1,87 @@
+"""
+"""
+from jax import numpy as jnp
+from jax import jit as jjit
+from jax import vmap
+
+C0 = 1 / 2
+C1 = 35 / 96
+C3 = -35 / 864
+C5 = 7 / 2592
+C7 = -5 / 69984
+
+LGYR_STELLAR_AGE_MIN = 5.0
+DELTA_LGYR_STELLAR_AGES = 0.05
+LGYR_BURST_DURATION_MAX = 9.0
+DEFAULT_DBURST = 2.0
+
+
+@jjit
+def _tw_cuml_kern(x, m, h):
+    """Triweight kernel version of an err function."""
+    z = (x - m) / h
+    zz = z * z
+    zzz = zz * z
+    val = C0 + C1 * z + C3 * zzz + C5 * zzz * zz + C7 * zzz * zzz * z
+    val = jnp.where(z < -3, 0, val)
+    val = jnp.where(z > 3, 1, val)
+    return val
+
+
+@jjit
+def _tw_sigmoid(x, x0, tw_h, ymin, ymax):
+    height_diff = ymax - ymin
+    body = _tw_cuml_kern(x, x0, tw_h)
+    return ymin + height_diff * body
+
+
+@jjit
+def _burst_age_weights_kern(lgyr_since_burst, lgyr_burst_duration, lgyr_age_min):
+    delta = lgyr_burst_duration - lgyr_age_min
+    x0 = lgyr_age_min + delta / 2.0
+    tw_h = delta / 6.0
+    return _tw_sigmoid(lgyr_since_burst, x0, tw_h, 1.0, 0.0)
+
+
+@jjit
+def _get_lgyr_burst_duration(dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max):
+    lgyr_min = lgyr_age_min + delta_lgyr_ages
+    lgyr_max = lgyr_burst_max
+    dlgyr_tot = lgyr_max - lgyr_min
+    tw_h = dlgyr_tot / 6.0
+    x0 = (lgyr_max - lgyr_min) / 2.0
+    lgyr_burst_duration = _tw_sigmoid(dburst, x0, tw_h, lgyr_min, lgyr_max)
+    return lgyr_burst_duration
+
+
+@jjit
+def _burst_age_weights_cdf(
+    lgyr_since_burst,
+    dburst,
+    lgyr_age_min=LGYR_STELLAR_AGE_MIN,
+    delta_lgyr_ages=DELTA_LGYR_STELLAR_AGES,
+    lgyr_burst_max=LGYR_BURST_DURATION_MAX,
+):
+    lgyr_burst_duration = _get_lgyr_burst_duration(
+        dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max
+    )
+    return _burst_age_weights_kern(lgyr_since_burst, lgyr_burst_duration, lgyr_age_min)
+
+
+@jjit
+def _burst_age_weights(
+    lgyr_since_burst,
+    dburst,
+    lgyr_age_min=LGYR_STELLAR_AGE_MIN,
+    delta_lgyr_ages=DELTA_LGYR_STELLAR_AGES,
+    lgyr_burst_max=LGYR_BURST_DURATION_MAX,
+):
+    cdf = _burst_age_weights_cdf(
+        lgyr_since_burst, dburst, lgyr_age_min, delta_lgyr_ages, lgyr_burst_max
+    )
+    weights = cdf / jnp.sum(cdf)
+    return weights
+
+
+_A = (None, 0)
+_burst_age_weights_pop = jjit(vmap(_burst_age_weights, in_axes=_A))

--- a/dsps/ssp/tests/test_diffburst.py
+++ b/dsps/ssp/tests/test_diffburst.py
@@ -1,0 +1,42 @@
+"""
+"""
+import numpy as np
+from .. import diffburst as db
+
+
+def test_burst_age_weights_cdf_is_monotonic():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.all(np.diff(res) <= 0)
+
+
+def test_burst_age_weights_cdf_is_correctly_bounded():
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        log_age_yr = np.linspace(-500, 500, 1000)
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.all(res >= 0)
+        assert np.all(res <= 1)
+
+        log_age_yr = db.LGYR_STELLAR_AGE_MIN
+        res = db._burst_age_weights(log_age_yr, dburst)
+        assert np.allclose(res, 1.0, atol=1e-3)
+
+
+def test_burst_age_weights_cdf_never_vanishes_everywhere():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        log_age_yr = np.linspace(-500, 500, 1000)
+        res = db._burst_age_weights_cdf(log_age_yr, dburst)
+        assert np.any(res > 0)
+
+
+def test_burst_age_weights_sum_to_unity():
+    log_age_yr = np.linspace(-500, 500, 1000)
+    dburst_arr = np.linspace(-100, 100, 50)
+    for dburst in dburst_arr:
+        res = db._burst_age_weights(log_age_yr, dburst)
+        assert np.allclose(np.sum(res), 1.0)


### PR DESCRIPTION
This PR brings in the Diffburst model of a PDF of stellar ages for a very young population. Diffburst is a two-parameter family for P(τ_age) based on a triweight function. The first parameter, τ_burst, controls the timescale of the burst - smaller values of τ_burst produce younger stellar populations. The second parameter, F_burst, controls the normalization of the burst, defined as a fraction of the total mass formed at z_obs.

The plot below compares the τ_age PDF of a pure burst to a typical main sequence Diffstar galaxy.

![burst_age_pdf_tau_effect](https://user-images.githubusercontent.com/6951595/228675709-69a76387-e6d0-41a7-8641-683ca1847485.png)

This next plot shows how the composite τ_age PDF looks for a few different variations in F_burst and τ_burst.
 
![burst_age_pdf_fburst_tburst_effect](https://user-images.githubusercontent.com/6951595/228675156-8924da37-830b-45bf-a2f3-c6819d7403f3.png)

This last plot shows how the pure-burst SED compares to the Diffstar SED, as well as a couple of composite spectra.
![variable_burst_sed_clip](https://user-images.githubusercontent.com/6951595/228676209-6abee8b1-cc66-432e-914c-41b58fc0c70f.png)

