### PR TITLE
Remove dependencies on diffmah and diffstar

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 diffmah
 numpy
 jax
-diffstar

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-diffmah
 numpy
 jax

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="ahearin@anl.gov",
     description="Differentiable Stellar Population Synthesis",
     long_description="Differentiable Stellar Population Synthesis",
-    install_requires=["numpy", "jax", "diffmah>=0.4.0", "diffstar>=0.1.0"],
+    install_requires=["numpy", "jax", "diffmah>=0.4.0"],
     packages=find_packages(),
     package_data={
         "dsps": [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="ahearin@anl.gov",
     description="Differentiable Stellar Population Synthesis",
     long_description="Differentiable Stellar Population Synthesis",
-    install_requires=["numpy", "jax", "diffmah>=0.4.0"],
+    install_requires=["numpy", "jax"],
     packages=find_packages(),
     package_data={
         "dsps": [


### PR DESCRIPTION
DSPS source code no longer uses these. This PR just removes them from `requirements.txt` and `setup.py`