### PR TITLE
Refactor internals in stellar age weight calculations

### DIFF
--- a/dsps/sed/stellar_age_weights.py
+++ b/dsps/sed/stellar_age_weights.py
@@ -10,20 +10,19 @@ def _calc_age_weights_from_sfh_table(
     gal_t_table, gal_sfr_table, ssp_lg_age, t_obs, sfr_min=SFR_MIN
 ):
     logsm_table = _calc_logsm_table_from_sfh_table(gal_t_table, gal_sfr_table, sfr_min)
-
+    gal_lgt_table = jnp.log10(gal_t_table)
     age_weights = _calc_age_weights_from_logsm_table(
-        gal_t_table, logsm_table, ssp_lg_age, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_age, t_obs
     )[1]
     return age_weights
 
 
 @jjit
-def _calc_age_weights_from_logsm_table(gal_t_table, logsm_table, ssp_lg_age, t_obs):
+def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age, t_obs):
     lg_age_bin_edges = _get_lg_age_bin_edges(ssp_lg_age)
     lgt_birth_bin_edges = _get_lgt_birth(t_obs, lg_age_bin_edges)
     lgt_birth_bin_mids = _get_lgt_birth(t_obs, ssp_lg_age)
 
-    lgt_table = jnp.log10(gal_t_table)
     logsm_at_t_birth_bin_edges = jnp.interp(lgt_birth_bin_edges, lgt_table, logsm_table)
     delta_mstar_at_t_birth = -jnp.diff(10**logsm_at_t_birth_bin_edges)
     age_weights = delta_mstar_at_t_birth / delta_mstar_at_t_birth.sum()

--- a/dsps/sed/tests/test_stellar_age_weights.py
+++ b/dsps/sed/tests/test_stellar_age_weights.py
@@ -28,11 +28,12 @@ def test_age_weights_are_mathematically_sensible():
     t_obs = 11.0
 
     gal_t_table = np.linspace(0.05, 13.8, 75)
+    gal_lgt_table = np.log10(gal_t_table)
     logsm_table = np.linspace(-1, 10, gal_t_table.size)
 
     ssp_lg_ages_gyr = FSPS_LG_AGES - 9.0
     lgt_birth_bin_mids, age_weights = _calc_age_weights_from_logsm_table(
-        gal_t_table, logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_ages_gyr, t_obs
     )
     assert age_weights.shape == lgt_birth_bin_mids.shape
     assert age_weights.shape == ssp_lg_ages_gyr.shape
@@ -51,11 +52,12 @@ def test_age_weights_agree_with_analytical_calculation_of_constant_sfr_weights()
     # Calculate age distributions with DSPS
     t_obs = 16.0
     gal_t_table = np.linspace(T_BIRTH_MIN, t_obs, 50_000)
+    gal_lgt_table = np.log10(gal_t_table)
     mstar_table = constant_sfr * gal_t_table
     logsm_table = np.log10(mstar_table)
 
     dsps_age_weights = _calc_age_weights_from_logsm_table(
-        gal_t_table, logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_ages_gyr, t_obs
     )[1]
     assert np.allclose(dsps_age_weights, correct_weights, atol=0.01)
 
@@ -74,9 +76,10 @@ def test_age_weights_agree_with_analytical_calculation_of_linear_sfr_weights():
 
     # Calculate age distributions with DSPS
     gal_t_table = np.linspace(T_BIRTH_MIN, t_obs, 50_000)
+    gal_lgt_table = np.log10(gal_t_table)
 
     logsm_table = np.log10(linear_smh(T_BIRTH_MIN, gal_t_table[1:]))
     dsps_age_weights = _calc_age_weights_from_logsm_table(
-        gal_t_table[1:], logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table[1:], logsm_table, ssp_lg_ages_gyr, t_obs
     )[1]
     assert np.allclose(dsps_age_weights, correct_weights, atol=0.001)


### PR DESCRIPTION
This PR changes the API of `_calc_age_weights_from_logsm_table`, an internal function called by `_calc_age_weights_from_sfh_table`. The `_calc_age_weights_from_sfh_table` accepts an input linear time argument in log-space, and it computes log10(time) within its namespace, since this function requires both logspace and linear space time computations. But the `_calc_age_weights_from_sfh_table` now accepts log10(t), since all this function does is interpolate log10(t) against logsm. It's a reasonably common use-case to call `_calc_age_weights_from_logsm_table` directly, and so this internal API change now means users don't have to take an extra logarithm if they have computed it already. But this PR leaves the behavior of `_calc_age_weights_from_sfh_table` unchanged.
