### PR TITLE
Add support for Lower+22 unobscured fractions in effective attenuation curves

### DIFF
--- a/dsps/dust/attenuation_kernels.py
+++ b/dsps/dust/attenuation_kernels.py
@@ -169,7 +169,9 @@ def _get_filter_effective_wavelength(filter_wave, filter_trans, redshift):
 
 
 @jjit
-def _get_effective_attenuation(filter_wave, filter_trans, redshift, dust_params):
+def _get_effective_attenuation(
+    filter_wave, filter_trans, redshift, dust_params, frac_unobscured=0.0
+):
     """Attenuation factor at the effective wavelength of the filter"""
 
     lambda_eff = _get_filter_effective_wavelength(filter_wave, filter_trans, redshift)
@@ -181,5 +183,5 @@ def _get_effective_attenuation(filter_wave, filter_trans, redshift, dust_params)
     axEbv = sbl18_k_lambda(
         lambda_eff_micron, dust_x0_microns, bump_width_microns, dust_Eb, dust_delta
     )
-    attenuation_factor = _flux_ratio(axEbv, RV_C00, dust_Av)
+    attenuation_factor = _flux_ratio(axEbv, RV_C00, dust_Av, frac_unobscured)
     return attenuation_factor


### PR DESCRIPTION
This PR builds on #20 by exposing the Lower+2022 unobscured fraction feature to the `_get_effective_attenuation` function. The plot below illustrates the character of the DoF of the unobscured fraction on the attenuation fraction.

![lower22_demo](https://user-images.githubusercontent.com/6951595/230435790-a17d3d15-3d33-447e-8778-c1a1455deae3.png)
