### PR TITLE
Fix hard-coded version in conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,15 +1,18 @@
-# Configuration file for the Sphinx documentation builder.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
+"""
+"""
+from pkg_resources import DistributionNotFound, get_distribution
 
-# -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+try:
+    __version__ = get_distribution("emcee").version
+except DistributionNotFound:
+    __version__ = "unknown version"
+
 
 project = "dsps"
 copyright = "2023, Andrew Hearin"
 author = "Andrew Hearin"
-release = "0.2.0"
+version = __version__
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration


### PR DESCRIPTION
Was previously hard-coded to `"0.2.0"`. Now version is inferred using `pkg_resources.get_distribution`