### PR TITLE
Add load_filter_data.py module to data_loaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dsps/_version.py
 # Ignore hdf5 data (incl DSPS data that may have been downloaded within package drn)
 *.h5
 
+# Ignore .npy data (incl DSPS data that may have been downloaded within package drn)
+*.npy
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dsps/__init__.py
+++ b/dsps/__init__.py
@@ -3,5 +3,6 @@
 """
 from ._version import __version__
 
-from .data_loaders import load_ssp_templates
+from .data_loaders import load_ssp_templates, load_transmission_curve
 from .sed import *
+from .photometry import *

--- a/dsps/data_loaders/__init__.py
+++ b/dsps/data_loaders/__init__.py
@@ -4,3 +4,4 @@
 from .defaults import DEFAULT_SSP_BNAME, DEFAULT_SSP_KEYS
 from .retrieve_fsps_data import retrieve_ssp_data_from_fsps
 from .load_ssp_data import SSPData, load_ssp_templates
+from .load_filter_data import load_transmission_curve

--- a/dsps/data_loaders/defaults.py
+++ b/dsps/data_loaders/defaults.py
@@ -30,3 +30,18 @@ class SSPData(typing.NamedTuple):
 
 
 DEFAULT_SSP_KEYS = SSPData._fields
+
+
+class TransmissionCurve(typing.NamedTuple):
+    """NamedTuple with 2 entries storing info about the transmission curve
+
+    wave : ndarray of shape (n, )
+        Array of λ/AA
+
+    transmission : ndarray of shape (n, )
+        Fraction of the flux transmitted through the filter
+
+    """
+
+    wave: np.ndarray
+    transmission: np.ndarray

--- a/dsps/data_loaders/load_filter_data.py
+++ b/dsps/data_loaders/load_filter_data.py
@@ -1,0 +1,71 @@
+"""
+"""
+import os
+from glob import glob
+import numpy as np
+from .defaults import TransmissionCurve
+
+
+def load_transmission_curve(fn=None, bn_pat=None, drn=None):
+    """Load filter transmission curves from disk,
+    defaulting to DSPS package data location
+
+    Parameters
+    ----------
+    fn : string, optional
+        Absolute path to file storing the transmission curve.
+        This argument supersedes drn and bn_pat.
+        Default is None, in which case DSPS will look in the filters subdirectory
+        of the drn stored in the DSPS_DRN environment variable
+
+    bn_pat : string, optional
+        Basename pattern of file storing the transmission curve.
+        For example, "lsst_r*" or "suprimecam_b*"
+        There must exist a uniquely matching file in the input drn.
+
+    drn : string, optional
+        Directory to files storing filter transmission curves
+        This argument is only used if fn is not supplied
+        Default behavior is the filters subdirectory
+        of the drn stored in the DSPS_DRN environment variable
+
+    bn : string, optional
+        Basename of file storing the filter transmission curve.
+        This argument is only used if fn is not supplied
+
+    Returns
+    -------
+    NamedTuple with 2 entries storing the transmission curve
+
+        wave : ndarray of shape (n, )
+            Array of λ/AA
+
+        transmission : ndarray of shape (n, )
+            Fraction of the flux transmitted through the filter
+
+    """
+    if fn is None:
+        if drn is None:
+            try:
+                drn = os.environ["DSPS_DRN"]
+                drn = os.path.join(drn, "filters")
+                assert os.path.isdir(drn), "Directory does not exist:\n{0}".format(drn)
+            except KeyError:
+                msg = (
+                    "Since you did not pass the fn or drn argument\n"
+                    "then you must have the DSPS_DRN environment variable set"
+                )
+                raise ValueError(msg)
+
+        fn_pat = os.path.join(drn, bn_pat)
+        fn_list = glob(fn_pat)
+        msg = "There is no filename with pattern {0} located in {1}"
+        assert len(fn_list) != 0, msg.format(bn_pat, drn)
+        msg = "There is more than one matching filename with pattern {0} located in {1}"
+        assert len(fn_list) < 2, msg.format(bn_pat, drn)
+        fn = fn_list[0]
+
+    assert os.path.isfile(fn), "{0} does not exist".format(fn)
+    data = np.load(fn)
+
+    return TransmissionCurve(data["wave"], data["transmission"])

--- a/dsps/data_loaders/load_ssp_data.py
+++ b/dsps/data_loaders/load_ssp_data.py
@@ -30,10 +30,6 @@ def load_ssp_templates(
         Basename of hdf5 file storing the SSP data
         This argument is only used if fn is not supplied
 
-    dummy : bool, optional
-        If True, function will return dummy data instead of real SSP data
-        Default is False. This option is only for unit-testing purposes.
-
     Returns
     -------
     NamedTuple with 4 entries storing info about SSP templates

--- a/dsps/data_loaders/tests/test_load_filter_data.py
+++ b/dsps/data_loaders/tests/test_load_filter_data.py
@@ -1,0 +1,49 @@
+"""
+"""
+import os
+import pytest
+import numpy as np
+from glob import glob
+from ..load_filter_data import load_transmission_curve
+from ..defaults import TransmissionCurve
+
+DSPS_DATA_DRN = os.environ.get("DSPS_DRN", None)
+ENV_VAR_MSG = "load_transmission_curve can only be tested if DSPS_DRN is in the env"
+
+APH_DSPS_DRN = "/Users/aphearin/work/DATA/DSPS_data"
+
+
+def _enforce_filter_is_sensible(filter_data):
+    assert len(filter_data) == len(TransmissionCurve._fields)
+    assert np.all(np.isfinite(filter_data.wave))
+    assert np.all(np.isfinite(filter_data.transmission))
+    assert np.all(filter_data.transmission >= 0)
+    assert np.all(filter_data.transmission <= 1)
+    assert np.any(filter_data.transmission > 0)
+
+
+@pytest.mark.skipif(DSPS_DATA_DRN is None, reason=ENV_VAR_MSG)
+def test_load_any_existent_filter_data_from_fnames():
+    drn = os.path.join(DSPS_DATA_DRN, "filters")
+    fn_list = glob(os.path.join(drn, "*transmission.npy"))
+    for fn in fn_list:
+        filter_data = load_transmission_curve(fn=fn)
+        _enforce_filter_is_sensible(filter_data)
+
+
+@pytest.mark.skipif(DSPS_DATA_DRN is None, reason=ENV_VAR_MSG)
+def test_load_any_existent_filter_data_from_bnpat():
+    drn = os.path.join(DSPS_DATA_DRN, "filters")
+    fn_list = glob(os.path.join(drn, "*transmission.npy"))
+    bn_list = [os.path.basename(fn) for fn in fn_list]
+
+    if APH_DSPS_DRN == DSPS_DATA_DRN:
+        assert len(bn_list) > 0
+
+    for bn_pat in bn_list:
+        filter_data = load_transmission_curve(bn_pat=bn_pat)
+        _enforce_filter_is_sensible(filter_data)
+
+    for bn_pat in bn_list:
+        filter_data = load_transmission_curve(drn=drn, bn_pat=bn_pat)
+        _enforce_filter_is_sensible(filter_data)


### PR DESCRIPTION
New load_filter_data.py module reads transmission curves stored to disk, optionally searching DSPS_DRN as the default location