### PR TITLE
Switch data format to h5 for filter transmission curves

### DIFF
--- a/dsps/data_loaders/load_filter_data.py
+++ b/dsps/data_loaders/load_filter_data.py
@@ -2,7 +2,7 @@
 """
 import os
 from glob import glob
-import numpy as np
+import h5py
 from .defaults import TransmissionCurve
 
 
@@ -66,6 +66,8 @@ def load_transmission_curve(fn=None, bn_pat=None, drn=None):
         fn = fn_list[0]
 
     assert os.path.isfile(fn), "{0} does not exist".format(fn)
-    data = np.load(fn)
+    with h5py.File(fn, "r") as hdf:
+        wave = hdf["wave"][...]
+        transmission = hdf["transmission"][...]
 
-    return TransmissionCurve(data["wave"], data["transmission"])
+    return TransmissionCurve(wave, transmission)

--- a/dsps/data_loaders/tests/test_load_filter_data.py
+++ b/dsps/data_loaders/tests/test_load_filter_data.py
@@ -25,7 +25,7 @@ def _enforce_filter_is_sensible(filter_data):
 @pytest.mark.skipif(DSPS_DATA_DRN is None, reason=ENV_VAR_MSG)
 def test_load_any_existent_filter_data_from_fnames():
     drn = os.path.join(DSPS_DATA_DRN, "filters")
-    fn_list = glob(os.path.join(drn, "*transmission.npy"))
+    fn_list = glob(os.path.join(drn, "*transmission.h5"))
     for fn in fn_list:
         filter_data = load_transmission_curve(fn=fn)
         _enforce_filter_is_sensible(filter_data)
@@ -34,7 +34,7 @@ def test_load_any_existent_filter_data_from_fnames():
 @pytest.mark.skipif(DSPS_DATA_DRN is None, reason=ENV_VAR_MSG)
 def test_load_any_existent_filter_data_from_bnpat():
     drn = os.path.join(DSPS_DATA_DRN, "filters")
-    fn_list = glob(os.path.join(drn, "*transmission.npy"))
+    fn_list = glob(os.path.join(drn, "*transmission.h5"))
     bn_list = [os.path.basename(fn) for fn in fn_list]
 
     if APH_DSPS_DRN == DSPS_DATA_DRN:


### PR DESCRIPTION
The previous filter_data pr #47 assumed `.npy` format for filter transmission curves. This PR changes the data convention to hdf5.