### PR TITLE
Add calculator of age of the universe at z

### DIFF
--- a/docs/source/dsps_quickstart.ipynb
+++ b/docs/source/dsps_quickstart.ipynb
@@ -58,7 +58,7 @@
     "1. a galaxy with a tabulated star formation history (SFH), and metallicity Z distributed as a lognormal about some median Z, using the `calc_rest_sed_sfh_table_lognormal_mdf` function. \n",
     "2. a galaxy with SFH table and also tabulated history of metallicity (ZH), using the `calc_rest_sed_sfh_table_met_table` function.\n",
     "\n",
-    "In the cells below, we'll randomly generate an SFH and ZH for a galaxy, and plot the results."
+    "In the cells below, we'll randomly generate an SFH and ZH for a galaxy, and then plot the results."
    ]
   },
   {
@@ -74,9 +74,31 @@
     "gal_sfr_table = np.random.uniform(0, 10, gal_t_table.size) # SFR in Msun/yr\n",
     "\n",
     "gal_lgmet = -2.0 # log10(Z)\n",
-    "gal_lgmet_scatter = 0.2 # lognormal scatter in the metallicity distribution function\n",
+    "gal_lgmet_scatter = 0.2 # lognormal scatter in the metallicity distribution function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31daa8a6",
+   "metadata": {},
+   "source": [
+    "The SED calculating functions require you specify the _time_ of the observation, `t_obs`, rather than the redshift, `z_obs`. We'll use the `age_at_z` function in `dsps.cosmology` to calculate the relationship between these two quantities, assuming the default redshift of DSPS. You could also use this same function to compute `gal_t_table` in case your input SFH is tabulated as a function of redshift."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14c9f1a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dsps.cosmology import age_at_z, DEFAULT_COSMOLOGY\n",
     "\n",
-    "t_obs = 8.0 # age of the universe in Gyr at z_obs"
+    "print(DEFAULT_COSMOLOGY)\n",
+    "\n",
+    "z_obs = 0.5\n",
+    "t_obs = age_at_z(z_obs, *DEFAULT_COSMOLOGY) # age of the universe in Gyr at z_obs\n",
+    "t_obs = t_obs[0] # age_at_z function returns an array, but SED functions accept a float for this argument"
    ]
   },
   {
@@ -180,26 +202,7 @@
    "source": [
     "### Calculating apparent magnitude\n",
     "\n",
-    "To calculate the apparent magnitude, we need to redshift the SED and also apply the appropriate cosmological dimming factor to the restframe flux. These calculations are done under-the-hood with the `flat_wcdm.py` module in `dsps.cosmology`, and so we just need to pass in the cosmological parameters. We'll do this using the default DSPS cosmology as shown below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "700c9179",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from dsps.cosmology import DSPS_DEFAULT_COSMOLOGY\n",
-    "print(DSPS_DEFAULT_COSMOLOGY)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "0ef1d235",
-   "metadata": {},
-   "source": [
-    "The DSPS cosmology functionality does not yet include a function that calculates the relationship between `z_obs` and `t_obs`, and so you'll need to calculate this relationship for yourself. In the cell below, we just use a precomputed result using [astropy](https://docs.astropy.org/en/stable/), but [jax_cosmo](https://github.com/DifferentiableUniverseInitiative/jax_cosmo) could be used for the same purpose."
+    "To calculate the apparent magnitude, we need to redshift the SED and also apply the appropriate cosmological dimming factor to the restframe flux. These calculations are done under-the-hood with the `flat_wcdm.py` module in `dsps.cosmology`, and so we just need to pass in the same cosmological parameters used above to calculate `t_obs` from `z_obs`."
    ]
   },
   {
@@ -210,9 +213,9 @@
    "outputs": [],
    "source": [
     "from dsps import calc_obs_mag\n",
-    "z_obs = 0.588\n",
+    "\n",
     "obs_mag = calc_obs_mag(ssp_data.ssp_wave, sed_info.rest_sed, lsst_g.wave, lsst_g.transmission,\n",
-    "                      z_obs, *DSPS_DEFAULT_COSMOLOGY)"
+    "                      z_obs, *DEFAULT_COSMOLOGY)"
    ]
   },
   {

--- a/dsps/constants.py
+++ b/dsps/constants.py
@@ -1,10 +1,5 @@
 """
 """
-import numpy as np
-
-# z=0 age of the universe for default cosmology
-TODAY = 13.79
-LGT0 = np.log10(TODAY)
 
 # Constants related to SFH integrals
 SFR_MIN = 1e-14

--- a/dsps/cosmology/__init__.py
+++ b/dsps/cosmology/__init__.py
@@ -3,4 +3,4 @@
 """
 from .flat_wcdm import *
 from .flat_wcdm import PLANCK15, WMAP5, FSPS_COSMO
-from .defaults import DSPS_DEFAULT_COSMOLOGY
+from .defaults import DEFAULT_COSMOLOGY, TODAY

--- a/dsps/cosmology/defaults.py
+++ b/dsps/cosmology/defaults.py
@@ -1,3 +1,8 @@
 # flake8: noqa
 """Globals storing defaults for various DSPS options"""
-from .flat_wcdm import PLANCK15 as DSPS_DEFAULT_COSMOLOGY
+from .flat_wcdm import PLANCK15 as DEFAULT_COSMOLOGY
+
+
+from .flat_wcdm import age_at_z0
+
+TODAY = age_at_z0(*DEFAULT_COSMOLOGY)

--- a/dsps/cosmology/tests/test_flat_wcdm.py
+++ b/dsps/cosmology/tests/test_flat_wcdm.py
@@ -7,6 +7,7 @@ from ..flat_wcdm import lookback_time, _Om, _delta_vir, virial_dynamical_time
 from ..flat_wcdm import PLANCK15 as PLANCK15_dsps
 from ..flat_wcdm import WMAP5 as WMAP5_dsps
 from ..flat_wcdm import CosmoParams
+from ..flat_wcdm import age_at_z, age_at_z0
 
 try:
     from astropy.cosmology import Planck15 as Planck15_astropy
@@ -131,3 +132,22 @@ def test_cosmology_defaults():
     from ...cosmology import DSPS_DEFAULT_COSMOLOGY, PLANCK15
 
     assert np.allclose(DSPS_DEFAULT_COSMOLOGY, PLANCK15)
+
+
+@pytest.mark.skipif(not HAS_ASTROPY, reason=NO_ASTROPY_MSG)
+def test_age_at_z():
+    zray = np.linspace(0.001, 10, 500)
+    for cosmo in ASTROPY_COSMO_LIST:
+        cosmo_dsps = CosmoParams(cosmo.Om0, -1, 0, cosmo.h)
+        age_astropy = cosmo.age(zray).value
+        age_jax = age_at_z(zray, *cosmo_dsps)
+        assert np.allclose(age_astropy, age_jax, rtol=0.01)
+
+
+@pytest.mark.skipif(not HAS_ASTROPY, reason=NO_ASTROPY_MSG)
+def test_age_at_z0():
+    for cosmo in ASTROPY_COSMO_LIST:
+        cosmo_dsps = CosmoParams(cosmo.Om0, -1, 0, cosmo.h)
+        age_astropy = cosmo.age(0.0).value
+        age_jax = age_at_z0(*cosmo_dsps)
+        assert np.allclose(age_astropy, age_jax, rtol=0.01)

--- a/dsps/cosmology/tests/test_flat_wcdm.py
+++ b/dsps/cosmology/tests/test_flat_wcdm.py
@@ -129,9 +129,9 @@ def test_dynamical_time():
 
 
 def test_cosmology_defaults():
-    from ...cosmology import DSPS_DEFAULT_COSMOLOGY, PLANCK15
+    from ...cosmology import DEFAULT_COSMOLOGY, PLANCK15
 
-    assert np.allclose(DSPS_DEFAULT_COSMOLOGY, PLANCK15)
+    assert np.allclose(DEFAULT_COSMOLOGY, PLANCK15)
 
 
 @pytest.mark.skipif(not HAS_ASTROPY, reason=NO_ASTROPY_MSG)

--- a/dsps/sed/stellar_age_weights.py
+++ b/dsps/sed/stellar_age_weights.py
@@ -2,7 +2,8 @@
 from jax import numpy as jnp
 from jax import jit as jjit
 from ..utils import _jax_get_dt_array
-from ..constants import SFR_MIN, T_BIRTH_MIN, TODAY, N_T_LGSM_INTEGRATION
+from ..constants import SFR_MIN, T_BIRTH_MIN, N_T_LGSM_INTEGRATION
+from ..cosmology import TODAY
 
 
 @jjit
@@ -79,8 +80,13 @@ def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age, t_obs
 
 
 @jjit
-def _get_linspace_time_tables():
+def _get_linspace_time_tables(t0=TODAY):
     """Convenience function returning time arrays used in SFH integrations
+
+    Parameters
+    ----------
+    t0 : float, optional
+        Age of the universe in Gyr at z=0
 
     Returns
     -------
@@ -94,7 +100,7 @@ def _get_linspace_time_tables():
         Duration in Gyr between the midpoints bracketing each element of t_table
 
     """
-    t_table = jnp.linspace(T_BIRTH_MIN, TODAY, N_T_LGSM_INTEGRATION)
+    t_table = jnp.linspace(T_BIRTH_MIN, t0, N_T_LGSM_INTEGRATION)
     lgt_table = jnp.log10(t_table)
     dt_table = _jax_get_dt_array(t_table)
     return t_table, lgt_table, dt_table


### PR DESCRIPTION
This PR brings in a new function `cosmology.flat_wcdm.age_at_z`, and removes the previously hard-coded value of dsps.TODAY.
Resolves #50.