### PR TITLE
Change variable names ssp_lg_age ==> ssp_lg_age_gyr

### DIFF
--- a/docs/source/dsps_quickstart.ipynb
+++ b/docs/source/dsps_quickstart.ipynb
@@ -43,7 +43,7 @@
     "print(ssp_data._fields)\n",
     "\n",
     "print('\\nssp_lgmet.shape = {}'.format(ssp_data.ssp_lgmet.shape))\n",
-    "print('ssp_lg_age.shape = {}'.format(ssp_data.ssp_lg_age.shape))\n",
+    "print('ssp_lg_age_gyr.shape = {}'.format(ssp_data.ssp_lg_age_gyr.shape))\n",
     "print('ssp_wave.shape = {}'.format(ssp_data.ssp_wave.shape))\n",
     "print('ssp_flux.shape = {}'.format(ssp_data.ssp_flux.shape))"
    ]
@@ -113,14 +113,14 @@
     "\n",
     "sed_info = calc_rest_sed_sfh_table_lognormal_mdf(\n",
     "    gal_t_table, gal_sfr_table, gal_lgmet, gal_lgmet_scatter,\n",
-    "    ssp_data.ssp_lgmet, ssp_data.ssp_lg_age, ssp_data.ssp_flux, t_obs)\n",
+    "    ssp_data.ssp_lgmet, ssp_data.ssp_lg_age_gyr, ssp_data.ssp_flux, t_obs)\n",
     "\n",
     "\n",
     "gal_lgmet_table = np.linspace(-3, -2, gal_t_table.size)\n",
     "\n",
     "sed_info2 = calc_rest_sed_sfh_table_met_table(\n",
     "    gal_t_table, gal_sfr_table, gal_lgmet_table, gal_lgmet_scatter,\n",
-    "    ssp_data.ssp_lgmet, ssp_data.ssp_lg_age, ssp_data.ssp_flux, t_obs)"
+    "    ssp_data.ssp_lgmet, ssp_data.ssp_lg_age_gyr, ssp_data.ssp_flux, t_obs)"
    ]
   },
   {

--- a/dsps/data_loaders/defaults.py
+++ b/dsps/data_loaders/defaults.py
@@ -13,7 +13,7 @@ class SSPData(typing.NamedTuple):
         Array of log10(Z) of the SSP templates
         where dimensionless Z is the mass fraction of elements heavier than He
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the SSP templates
 
     ssp_wave : ndarray of shape (n_wave, )
@@ -24,7 +24,7 @@ class SSPData(typing.NamedTuple):
     """
 
     ssp_lgmet: np.ndarray
-    ssp_lg_age: np.ndarray
+    ssp_lg_age_gyr: np.ndarray
     ssp_wave: np.ndarray
     ssp_flux: np.ndarray
 

--- a/dsps/data_loaders/load_ssp_data.py
+++ b/dsps/data_loaders/load_ssp_data.py
@@ -38,7 +38,7 @@ def load_ssp_templates(
             Array of log10(Z) of the SSP templates
             where dimensionless Z is the mass fraction of elements heavier than He
 
-        ssp_lg_age : ndarray of shape (n_ages, )
+        ssp_lg_age_gyr : ndarray of shape (n_ages, )
             Array of log10(age/Gyr) of the SSP templates
 
         ssp_wave : ndarray of shape (n_wave, )

--- a/dsps/data_loaders/retrieve_fake_fsps_data.py
+++ b/dsps/data_loaders/retrieve_fake_fsps_data.py
@@ -11,10 +11,10 @@ _THIS_DRNAME = os.path.dirname(os.path.abspath(__file__))
 
 def load_fake_ssp_data():
     ssp_lgmet = _get_lgzlegend()
-    ssp_lg_age = _get_log_age_gyr()
+    ssp_lg_age_gyr = _get_log_age_gyr()
     ssp_wave = _get_ssp_wave()
     ssp_flux = _get_spec_ssp()
-    return SSPData(ssp_lgmet, ssp_lg_age, ssp_wave, ssp_flux)
+    return SSPData(ssp_lgmet, ssp_lg_age_gyr, ssp_wave, ssp_flux)
 
 
 def load_fake_filter_transmission_curves():

--- a/dsps/data_loaders/retrieve_fsps_data.py
+++ b/dsps/data_loaders/retrieve_fsps_data.py
@@ -21,7 +21,7 @@ def retrieve_ssp_data_from_fsps():
         Array of log10(Z) of the SSP templates
         where dimensionless Z is the mass fraction of elements heavier than He
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the SSP templates
 
     ssp_wave : ndarray of shape (n_wave, )
@@ -47,7 +47,7 @@ def retrieve_ssp_data_from_fsps():
     sp = fsps.StellarPopulation(zcontinuous=0)
     ssp_lgmet = np.log10(sp.zlegend)
     nzmet = ssp_lgmet.size
-    ssp_lg_age = sp.log_age - 9.0
+    ssp_lg_age_gyr = sp.log_age - 9.0
     spectrum_collector = []
     for zmet_indx in range(1, ssp_lgmet.size + 1):
         print("...retrieving zmet = {0} of {1}".format(zmet_indx, nzmet))
@@ -59,4 +59,4 @@ def retrieve_ssp_data_from_fsps():
     ssp_wave = np.array(_wave)
     ssp_flux = np.array(spectrum_collector)
 
-    return SSPData(ssp_lgmet, ssp_lg_age, ssp_wave, ssp_flux)
+    return SSPData(ssp_lgmet, ssp_lg_age_gyr, ssp_wave, ssp_flux)

--- a/dsps/data_loaders/tests/test_load_ssp_data.py
+++ b/dsps/data_loaders/tests/test_load_ssp_data.py
@@ -18,3 +18,11 @@ def test_load_ssp_templates():
 def test_load_dummy_ssp_templates():
     ssp_data = load_ssp_templates(dummy=True)
     assert len(ssp_data) == len(SSPData._fields)
+
+
+def test_and_freeze_sspdata_field_names():
+    ssp_data = SSPData(None, None, None, None)
+    ssp_lgmet = ssp_data.ssp_lgmet
+    ssp_lg_age_gyr = ssp_data.ssp_lg_age_gyr
+    ssp_wave = ssp_data.ssp_wave
+    ssp_flux = ssp_data.ssp_flux

--- a/dsps/data_loaders/tests/test_retrieve_fake_fsps_data.py
+++ b/dsps/data_loaders/tests/test_retrieve_fake_fsps_data.py
@@ -10,11 +10,11 @@ def test_load_fake_ssp_data():
     (n_met, n_age, n_wave) = ssp_data.ssp_flux.shape
 
     assert ssp_data.ssp_lgmet.shape == (n_met,)
-    assert ssp_data.ssp_lg_age.shape == (n_age,)
+    assert ssp_data.ssp_lg_age_gyr.shape == (n_age,)
     assert ssp_data.ssp_wave.shape == (n_wave,)
 
     assert np.all(np.isfinite(ssp_data.ssp_lgmet))
-    assert np.all(np.isfinite(ssp_data.ssp_lg_age))
+    assert np.all(np.isfinite(ssp_data.ssp_lg_age_gyr))
     assert np.all(np.isfinite(ssp_data.ssp_wave))
     assert np.all(np.isfinite(ssp_data.ssp_flux))
 

--- a/dsps/sed/metallicity_weights.py
+++ b/dsps/sed/metallicity_weights.py
@@ -48,7 +48,7 @@ def calc_lgmet_weights_from_lgmet_table(
     gal_lgmet_table,
     gal_lgmet_scatter,
     ssp_lgmet,
-    ssp_lg_age,
+    ssp_lg_age_gyr,
     t_obs,
 ):
     """Calculate PDF-weights from a tabulated metallicity history
@@ -67,7 +67,7 @@ def calc_lgmet_weights_from_lgmet_table(
     ssp_lgmet : ndarray of shape (n_ages, )
         Array of log10(Z) of the SSP templates
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the stellar ages of the SSP templates
 
     Returns
@@ -77,7 +77,7 @@ def calc_lgmet_weights_from_lgmet_table(
 
     """
     lgmet_at_ssp_lgages = _calc_lgmet_at_ssp_lgage_table(
-        gal_t_table, gal_lgmet_table, ssp_lg_age, t_obs
+        gal_t_table, gal_lgmet_table, ssp_lg_age_gyr, t_obs
     )
 
     lgmetbin_edges = _get_bin_edges(ssp_lgmet, LGMET_LO, LGMET_HI)
@@ -85,7 +85,7 @@ def calc_lgmet_weights_from_lgmet_table(
         lgmet_at_ssp_lgages, gal_lgmet_scatter, lgmetbin_edges
     )
     # Normalize so that sum of all matrix elements is unity
-    lgmet_weight_matrix = lgmet_weight_matrix / ssp_lg_age.size
+    lgmet_weight_matrix = lgmet_weight_matrix / ssp_lg_age_gyr.size
 
     lgmet_weight_matrix = jnp.swapaxes(lgmet_weight_matrix, 1, 0)
 
@@ -112,8 +112,8 @@ _get_lgmet_weights_singlegal_zh = jjit(vmap(_get_lgmet_weights_singlegal, in_axe
 
 
 @jjit
-def _calc_lgmet_at_ssp_lgage_table(gal_t_table, gal_lgmet_table, ssp_lg_age, t_obs):
+def _calc_lgmet_at_ssp_lgage_table(gal_t_table, gal_lgmet_table, ssp_lg_age_gyr, t_obs):
     lgt_table = jnp.log10(gal_t_table)
-    lgt_birth = _get_lgt_birth(t_obs, ssp_lg_age)
+    lgt_birth = _get_lgt_birth(t_obs, ssp_lg_age_gyr)
     lgmet_at_ssp_lgages = jnp.interp(lgt_birth, lgt_table, gal_lgmet_table)
     return lgmet_at_ssp_lgages

--- a/dsps/sed/ssp_weights.py
+++ b/dsps/sed/ssp_weights.py
@@ -25,7 +25,7 @@ def calc_ssp_weights_sfh_table_lognormal_mdf(
     gal_lgmet,
     gal_lgmet_scatter,
     ssp_lgmet,
-    ssp_lg_age,
+    ssp_lg_age_gyr,
     t_obs,
 ):
     """Calculate SSP weights of a tabulated SFH and a lognormal MDF
@@ -47,7 +47,7 @@ def calc_ssp_weights_sfh_table_lognormal_mdf(
     ssp_lgmet : ndarray of shape (n_ages, )
         Array of log10(Z) of the SSP templates
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the SSP templates
 
     t_obs : float
@@ -68,7 +68,7 @@ def calc_ssp_weights_sfh_table_lognormal_mdf(
 
     """
     age_weights = calc_age_weights_from_sfh_table(
-        gal_t_table, gal_sfr_table, ssp_lg_age, t_obs
+        gal_t_table, gal_sfr_table, ssp_lg_age_gyr, t_obs
     )
     lgmet_weights = calc_lgmet_weights_from_lognormal_mdf(
         gal_lgmet, gal_lgmet_scatter, ssp_lgmet
@@ -87,7 +87,7 @@ def calc_ssp_weights_sfh_table_met_table(
     gal_lgmet_table,
     gal_lgmet_scatter,
     ssp_lgmet,
-    ssp_lg_age,
+    ssp_lg_age_gyr,
     t_obs,
 ):
     """Calculate SSP weights of a tabulated star-formation and metallicity history
@@ -109,7 +109,7 @@ def calc_ssp_weights_sfh_table_met_table(
     ssp_lgmet : ndarray of shape (n_ages, )
         Array of log10(Z) of the SSP templates
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the stellar ages of the SSP templates
 
     t_obs : float
@@ -130,10 +130,15 @@ def calc_ssp_weights_sfh_table_met_table(
 
     """
     age_weights = calc_age_weights_from_sfh_table(
-        gal_t_table, gal_sfr_table, ssp_lg_age, t_obs
+        gal_t_table, gal_sfr_table, ssp_lg_age_gyr, t_obs
     )
     lgmet_weights = calc_lgmet_weights_from_lgmet_table(
-        gal_t_table, gal_lgmet_table, gal_lgmet_scatter, ssp_lgmet, ssp_lg_age, t_obs
+        gal_t_table,
+        gal_lgmet_table,
+        gal_lgmet_scatter,
+        ssp_lgmet,
+        ssp_lg_age_gyr,
+        t_obs,
     )
 
     weights = lgmet_weights * age_weights.reshape((1, -1))

--- a/dsps/sed/stellar_age_weights.py
+++ b/dsps/sed/stellar_age_weights.py
@@ -10,7 +10,7 @@ __all__ = ("calc_age_weights_from_sfh_table",)
 
 @jjit
 def calc_age_weights_from_sfh_table(
-    gal_t_table, gal_sfr_table, ssp_lg_age, t_obs, sfr_min=SFR_MIN
+    gal_t_table, gal_sfr_table, ssp_lg_age_gyr, t_obs, sfr_min=SFR_MIN
 ):
     """Calculate PDF-weights of stellar ages from a tabulated SFH
 
@@ -22,7 +22,7 @@ def calc_age_weights_from_sfh_table(
     gal_sfr_table : ndarray of shape (n_t, )
         Tabulation of the galaxy SFH in Msun/yr at the times gal_t_table
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         log10(stellar age) in Gyr of the SSP templates
 
     t_obs : float
@@ -37,13 +37,13 @@ def calc_age_weights_from_sfh_table(
     logsm_table = _calc_logsm_table_from_sfh_table(gal_t_table, gal_sfr_table, sfr_min)
     gal_lgt_table = jnp.log10(gal_t_table)
     age_weights = _calc_age_weights_from_logsm_table(
-        gal_lgt_table, logsm_table, ssp_lg_age, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_age_gyr, t_obs
     )[1]
     return age_weights
 
 
 @jjit
-def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age, t_obs):
+def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age_gyr, t_obs):
     """Calculate PDF weights of the SSP spectra of a composite SED
 
     Parameters
@@ -54,7 +54,7 @@ def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age, t_obs
     logsm_table : ndarray of shape (n_t, )
         log10 of the cumulative stellar mass formed in-situ at each time in lgt_table
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of stellar ages of the SSP templates
 
     t_obs : float
@@ -70,9 +70,9 @@ def _calc_age_weights_from_logsm_table(lgt_table, logsm_table, ssp_lg_age, t_obs
         PDF weights of the SSP spectra
 
     """
-    lg_age_bin_edges = _get_lg_age_bin_edges(ssp_lg_age)
+    lg_age_bin_edges = _get_lg_age_bin_edges(ssp_lg_age_gyr)
     lgt_birth_bin_edges = _get_lgt_birth(t_obs, lg_age_bin_edges)
-    lgt_birth_bin_mids = _get_lgt_birth(t_obs, ssp_lg_age)
+    lgt_birth_bin_mids = _get_lgt_birth(t_obs, ssp_lg_age_gyr)
 
     logsm_at_t_birth_bin_edges = jnp.interp(lgt_birth_bin_edges, lgt_table, logsm_table)
     delta_mstar_at_t_birth = -jnp.diff(10**logsm_at_t_birth_bin_edges)

--- a/dsps/sed/stellar_sed.py
+++ b/dsps/sed/stellar_sed.py
@@ -40,7 +40,7 @@ def calc_rest_sed_sfh_table_lognormal_mdf(
     gal_lgmet,
     gal_lgmet_scatter,
     ssp_lgmet,
-    ssp_lg_age,
+    ssp_lg_age_gyr,
     ssp_flux,
     t_obs,
     sfr_min=SFR_MIN,
@@ -67,7 +67,7 @@ def calc_rest_sed_sfh_table_lognormal_mdf(
     ssp_lgmet : ndarray of shape (n_met, )
         Array of log10(Z) of the SSP templates
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Array of log10(age/Gyr) of the SSP templates
 
     ssp_flux : ndarray of shape (n_met, n_ages, n_wave)
@@ -99,7 +99,7 @@ def calc_rest_sed_sfh_table_lognormal_mdf(
         gal_lgmet,
         gal_lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         t_obs,
     )
     n_met, n_ages = weights.shape
@@ -124,7 +124,7 @@ def calc_rest_sed_sfh_table_met_table(
     gal_lgmet_table,
     gal_lgmet_scatter,
     ssp_lgmet,
-    ssp_lg_age,
+    ssp_lg_age_gyr,
     ssp_flux,
     t_obs,
     sfr_min=SFR_MIN,
@@ -150,7 +150,7 @@ def calc_rest_sed_sfh_table_met_table(
     ssp_lgmet : ndarray of shape (n_met, )
         Metallicity of stellar populations of the input SSP table ssp_flux
 
-    ssp_lg_age : ndarray of shape (n_ages, )
+    ssp_lg_age_gyr : ndarray of shape (n_ages, )
         Age of stellar populations of the input SSP table ssp_flux
 
     ssp_flux : ndarray of shape (n_met, n_ages, n_wave)
@@ -182,7 +182,7 @@ def calc_rest_sed_sfh_table_met_table(
         gal_lgmet_table,
         gal_lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         t_obs,
     )
     n_met, n_ages = weights.shape

--- a/dsps/sed/tests/test_csp_sed.py
+++ b/dsps/sed/tests/test_csp_sed.py
@@ -21,7 +21,7 @@ def test_calc_rest_sed_lognormal_mdf():
     gal_sfr_table = jran.uniform(sfr_key, minval=0, maxval=10, shape=(n_t,))
 
     n_ages = FSPS_LG_AGES.size
-    ssp_lg_age = FSPS_LG_AGES - 9.0
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
     n_met = 15
     ssp_lgmet = np.linspace(-4, 0.5, n_met)
 
@@ -39,7 +39,7 @@ def test_calc_rest_sed_lognormal_mdf():
         gal_lgmet,
         gal_lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         ssp_flux,
         t_obs,
     )
@@ -69,7 +69,7 @@ def test_calc_rest_sed_lgmet_table():
     gal_sfr_table = jran.uniform(sfr_key, minval=0, maxval=10, shape=(n_t,))
 
     n_ages = FSPS_LG_AGES.size
-    ssp_lg_age = FSPS_LG_AGES - 9.0
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
     n_met = 15
     ssp_lgmet = np.linspace(-4, 0.5, n_met)
 
@@ -87,7 +87,7 @@ def test_calc_rest_sed_lgmet_table():
         gal_lgmet_table,
         gal_lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         ssp_flux,
         t_obs,
     )

--- a/dsps/sed/tests/test_metallicity_weights.py
+++ b/dsps/sed/tests/test_metallicity_weights.py
@@ -60,8 +60,8 @@ def test_calc_lgmet_weights_from_lgmet_table():
     gal_lgmet_table = jran.uniform(
         met_key, minval=ssp_lgmet.min(), maxval=ssp_lgmet.max(), shape=(n_t,)
     )
-    ssp_lg_age = FSPS_LG_AGES - 9.0
-    n_ages = ssp_lg_age.size
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
+    n_ages = ssp_lg_age_gyr.size
 
     lgmet_scatter = 0.1
     lgmet_weights = calc_lgmet_weights_from_lgmet_table(
@@ -69,7 +69,7 @@ def test_calc_lgmet_weights_from_lgmet_table():
         gal_lgmet_table,
         lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         t_obs,
     )
     assert lgmet_weights.shape == (n_met, n_ages)

--- a/dsps/sed/tests/test_ssp_weights.py
+++ b/dsps/sed/tests/test_ssp_weights.py
@@ -21,7 +21,7 @@ def test_calc_ssp_weights_lognormal_mdf():
     gal_sfr_table = jran.uniform(sfr_key, minval=0, maxval=10, shape=(n_t,))
 
     n_ages = FSPS_LG_AGES.size
-    ssp_lg_age = FSPS_LG_AGES - 9.0
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
     n_met = 15
     ssp_lgmet = np.linspace(-4, 0.5, n_met)
 
@@ -36,7 +36,7 @@ def test_calc_ssp_weights_lognormal_mdf():
         lgmet,
         lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         t_obs,
     )
     weight_info = calc_ssp_weights_sfh_table_lognormal_mdf(*args)
@@ -65,7 +65,7 @@ def test_calc_ssp_weights_met_table():
     gal_sfr_table = jran.uniform(sfr_key, minval=0, maxval=10, shape=(n_t,))
 
     n_ages = FSPS_LG_AGES.size
-    ssp_lg_age = FSPS_LG_AGES - 9.0
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
     n_met = 15
     ssp_lgmet = np.linspace(-4, 0.5, n_met)
 
@@ -80,7 +80,7 @@ def test_calc_ssp_weights_met_table():
         gal_lgmet_table,
         gal_lgmet_scatter,
         ssp_lgmet,
-        ssp_lg_age,
+        ssp_lg_age_gyr,
         t_obs,
     )
     weight_info = calc_ssp_weights_sfh_table_met_table(*args)

--- a/dsps/sed/tests/test_stellar_age_weights.py
+++ b/dsps/sed/tests/test_stellar_age_weights.py
@@ -31,12 +31,12 @@ def test_age_weights_are_mathematically_sensible():
     gal_lgt_table = np.log10(gal_t_table)
     logsm_table = np.linspace(-1, 10, gal_t_table.size)
 
-    ssp_lg_ages_gyr = FSPS_LG_AGES - 9.0
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9.0
     lgt_birth_bin_mids, age_weights = _calc_age_weights_from_logsm_table(
-        gal_lgt_table, logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_age_gyr, t_obs
     )
     assert age_weights.shape == lgt_birth_bin_mids.shape
-    assert age_weights.shape == ssp_lg_ages_gyr.shape
+    assert age_weights.shape == ssp_lg_age_gyr.shape
     assert np.allclose(age_weights.sum(), 1.0)
 
 
@@ -44,8 +44,8 @@ def test_age_weights_agree_with_analytical_calculation_of_constant_sfr_weights()
     constant_sfr = 1.0 * 1e9  # Msun/Gyr
 
     # Analytically calculate age distributions for constant SFR (independent of t_obs)
-    ssp_lg_ages_gyr = FSPS_LG_AGES - 9
-    dt_ages = _jax_get_dt_array(10**ssp_lg_ages_gyr)
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9
+    dt_ages = _jax_get_dt_array(10**ssp_lg_age_gyr)
     mstar_age_bins = dt_ages * constant_sfr
     correct_weights = mstar_age_bins / mstar_age_bins.sum()
 
@@ -57,7 +57,7 @@ def test_age_weights_agree_with_analytical_calculation_of_constant_sfr_weights()
     logsm_table = np.log10(mstar_table)
 
     dsps_age_weights = _calc_age_weights_from_logsm_table(
-        gal_lgt_table, logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table, logsm_table, ssp_lg_age_gyr, t_obs
     )[1]
     assert np.allclose(dsps_age_weights, correct_weights, atol=0.01)
 
@@ -66,8 +66,8 @@ def test_age_weights_agree_with_analytical_calculation_of_linear_sfr_weights():
     t_obs = 16.0
 
     # Analytically calculate age distributions for SFR(t) = t
-    ssp_lg_ages_gyr = FSPS_LG_AGES - 9
-    lgt_age_bin_edges = _get_lg_age_bin_edges(ssp_lg_ages_gyr)
+    ssp_lg_age_gyr = FSPS_LG_AGES - 9
+    lgt_age_bin_edges = _get_lg_age_bin_edges(ssp_lg_age_gyr)
     t_age_bin_edges_gyr = 10**lgt_age_bin_edges
     t_births_bin_edges = t_obs - t_age_bin_edges_gyr
     mstar_at_age_bins = linear_smh(T_BIRTH_MIN, t_births_bin_edges)
@@ -80,6 +80,6 @@ def test_age_weights_agree_with_analytical_calculation_of_linear_sfr_weights():
 
     logsm_table = np.log10(linear_smh(T_BIRTH_MIN, gal_t_table[1:]))
     dsps_age_weights = _calc_age_weights_from_logsm_table(
-        gal_lgt_table[1:], logsm_table, ssp_lg_ages_gyr, t_obs
+        gal_lgt_table[1:], logsm_table, ssp_lg_age_gyr, t_obs
     )[1]
     assert np.allclose(dsps_age_weights, correct_weights, atol=0.001)


### PR DESCRIPTION
The `ssp_lg_age_gyr` variable name denotes an array of stellar ages of the SSP library. This array is expected to be provided in Gyr throughout the code, and so this variable name now reinforces this expectation.

The SSP data stored at [the DSPS url](https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/) has also been updated so that the hdf5 key has been renamed. This means @gbeltzmo and @evevkovacs will need to update their data by re-downloading this file.