### PR TITLE
Import scipy.stats.norm from jax rather than scipy

### DIFF
--- a/dsps/data_loaders/retrieve_fake_fsps_data.py
+++ b/dsps/data_loaders/retrieve_fake_fsps_data.py
@@ -1,7 +1,7 @@
 """
 """
 import numpy as np
-from scipy.stats import norm
+from jax.scipy.stats import norm
 import os
 from .defaults import SSPData
 


### PR DESCRIPTION
This PR removes a forgotten/unintentional import from scipy rather than jax.scipy identified by [this PR in the dsps-feedstock](https://github.com/conda-forge/dsps-feedstock/pull/6)

CC @beckermr 