### PR TITLE
Replace jnp.exp --> lax.exp

### DIFF
--- a/dsps/cosmology/flat_wcdm.py
+++ b/dsps/cosmology/flat_wcdm.py
@@ -1,6 +1,8 @@
 """Kernels calculating distances in flat FLRW cosmologies"""
 import typing
+
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
 from jax import vmap
 
@@ -42,7 +44,7 @@ YEAR = 31556925.2  # year in seconds
 @jjit
 def _rho_de_z(z, w0, wa):
     a = 1.0 / (1.0 + z)
-    de_z = a ** (-3.0 * (1.0 + w0 + wa)) * jnp.exp(-3.0 * wa * (1.0 - a))
+    de_z = a ** (-3.0 * (1.0 + w0 + wa)) * lax.exp(-3.0 * wa * (1.0 - a))
     return de_z
 
 
@@ -347,4 +349,5 @@ def virial_dynamical_time(redshift, Om0, w0, wa, h):
     """
     delta = _delta_vir(redshift, Om0, w0, wa)
     t_cross = 2**1.5 * _hubble_time(redshift, Om0, w0, wa, h) * delta**-0.5
+    return t_cross
     return t_cross

--- a/dsps/dust/blackbody.py
+++ b/dsps/dust/blackbody.py
@@ -1,8 +1,8 @@
 """JAX implementation of a blackbody spectral energy density"""
 import numpy as np
-from jax import numpy as jnp
-from jax import jit as jjit
 from jax import config
+from jax import jit as jjit
+from jax import lax
 
 config.update("jax_enable_x64", True)
 
@@ -73,14 +73,14 @@ def _freq_density_denom(freq_hz, temp_kelvin):
     hnu = H_PLANCK * freq_hz
     kt = K_BOLTZ * temp_kelvin
     x = hnu / kt
-    denom = 1 / (jnp.exp(x) - 1)
+    denom = 1 / (lax.exp(x) - 1)
     return denom
 
 
 @jjit
 def _jax_bb_freq_density_exparg(freq_hz):
     lg_term1 = LG2 + LGH - 2 * LGC
-    lg_term2 = 3 * jnp.log(freq_hz)
+    lg_term2 = 3 * lax.log(freq_hz)
     exparg = lg_term1 + lg_term2
     return exparg
 
@@ -90,7 +90,7 @@ def _blackbody_freq_density_si(freq_hz, temp_kelvin):
     """Blackbody frequency density, L_ν, in SI units [W/Hz/sr/m/m]"""
     exparg = _jax_bb_freq_density_exparg(freq_hz)
     denom = _freq_density_denom(freq_hz, temp_kelvin)
-    return denom * jnp.exp(exparg)
+    return denom * lax.exp(exparg)
 
 
 @jjit
@@ -112,7 +112,7 @@ def _wave_density_denom(wave_meters, temp_kelvin):
     hc = H_PLANCK * C_SPEED
     kt = K_BOLTZ * temp_kelvin
     x = hc / kt / wave_meters
-    denom = 1 / (jnp.exp(x) - 1)
+    denom = 1 / (lax.exp(x) - 1)
     return denom
 
 
@@ -121,7 +121,7 @@ def _blackbody_wave_density_si(wave_m, temp_kelvin):
     """Blackbody wavelength density, L_λ, in SI units [W/m/sr/m/m]"""
     denom_factor = _wave_density_denom(wave_m, temp_kelvin)
     lg_term1 = LG2 + LGH + 2 * LGC
-    lg_term2 = 5 * jnp.log(wave_m)
+    lg_term2 = 5 * lax.log(wave_m)
     exparg = lg_term1 - lg_term2
-    wave_factor = jnp.exp(exparg)
+    wave_factor = lax.exp(exparg)
     return wave_factor * denom_factor

--- a/dsps/tests/test_utils.py
+++ b/dsps/tests/test_utils.py
@@ -2,20 +2,30 @@
 """
 import numpy as np
 from jax import random as jran
-from ..utils import triweighted_histogram, _get_bin_edges, _get_triweights_singlepoint
-from ..utils import _mult_2d_vmap, _get_weight_matrices_2d
-from ..utils import _mult_3d_vmap, _get_weight_matrices_3d
-from ..utils import _sigmoid, _inverse_sigmoid
-from ..utils import powerlaw_rvs, powerlaw_pdf
+
+from ..utils import (
+    _get_bin_edges,
+    _get_triweights_singlepoint,
+    _get_weight_matrices_2d,
+    _get_weight_matrices_3d,
+    _inverse_sigmoid,
+    _mult_2d_vmap,
+    _mult_3d_vmap,
+    _sigmoid,
+    powerlaw_pdf,
+    powerlaw_rvs,
+    triweighted_histogram,
+)
 
 
 def test_sigmoid_inversion():
-    xarr = np.linspace(-10, 10, 500)
+    xarr = np.linspace(-100, 100, 500)
 
     x0, k, ylo, yhi = 0, 0.1, -5, 5
     y = _sigmoid(xarr, x0, k, ylo, yhi)
     x2 = _inverse_sigmoid(y, x0, k, ylo, yhi)
-    assert np.allclose(xarr, x2, rtol=1e-4)
+    assert np.all(~np.isnan(x2))
+    assert np.allclose(xarr, x2, rtol=1e-2)
 
 
 def test_triweighted_histogram():
@@ -125,6 +135,15 @@ def test_powerlaw_rvs():
 
 def test_powerlaw_pdf():
     npts = 2_000
+    a = np.random.uniform(2, 3, npts)
+    b = a + np.random.uniform(0, 1, npts)
+    g = np.random.uniform(1, 4, npts)
+    x = np.random.uniform(a, b, npts)
+
+    pdf = powerlaw_pdf(x, a, b, g)
+    assert np.all(np.isfinite(pdf))
+    assert np.all(pdf >= 0)
+    assert np.any(pdf > 0)
     a = np.random.uniform(2, 3, npts)
     b = a + np.random.uniform(0, 1, npts)
     g = np.random.uniform(1, 4, npts)

--- a/dsps/utils.py
+++ b/dsps/utils.py
@@ -1,9 +1,10 @@
 """
 """
 from jax import jit as jjit
+from jax import lax
 from jax import numpy as jnp
-from jax import vmap
 from jax import random as jran
+from jax import vmap
 
 
 @jjit
@@ -149,13 +150,13 @@ def _get_triweights_singlepoint(x, sig, bin_edges):
 @jjit
 def _sigmoid(x, x0, k, ylo, yhi):
     height_diff = yhi - ylo
-    return ylo + height_diff / (1 + jnp.exp(-k * (x - x0)))
+    return ylo + height_diff * lax.logistic(k * (x - x0))
 
 
 @jjit
 def _inverse_sigmoid(y, x0, k, ylo, yhi):
     lnarg = (yhi - ylo) / (y - ylo) - 1
-    return x0 - jnp.log(lnarg) / k
+    return x0 - lax.log(lnarg) / k
 
 
 @jjit
@@ -241,4 +242,5 @@ def powerlaw_rvs(ran_key, a, b, g):
     npts = a.shape[0]
     r = jran.uniform(ran_key, (npts,))
     ag, bg = a**g, b**g
+    return (ag + (bg - ag) * r) ** (1.0 / g)
     return (ag + (bg - ag) * r) ** (1.0 / g)


### PR DESCRIPTION
This PR improves numerical robustness of the calls to the exponential function, resolving an issue leading to NaNs in gradients.