### PR TITLE
Add cumulative_mstar_formed function to dsps.utils

### DIFF
--- a/dsps/__init__.py
+++ b/dsps/__init__.py
@@ -2,7 +2,7 @@
 """
 """
 from ._version import __version__
-
 from .data_loaders import load_ssp_templates, load_transmission_curve
-from .sed import *
 from .photometry import *
+from .sed import *
+from .utils import cumulative_mstar_formed

--- a/dsps/constants.py
+++ b/dsps/constants.py
@@ -4,6 +4,7 @@
 # Constants related to SFH integrals
 SFR_MIN = 1e-14
 T_BIRTH_MIN = 0.001
+T_TABLE_MIN = 0.01
 N_T_LGSM_INTEGRATION = 100
 
 # Constants related to metallicity weights


### PR DESCRIPTION
This PR brings in a new kernel, `dsps.utils.cumulative_mstar_formed`, that computes the cumulative stellar mass formed from an input SFH table. A few notes:

* Trapezoidal integration is used to integrate an input `sfh_table` across an input `t_table` under the assumption that SFR=SFR_MIN during the interval `dsps.constants.T_BIRTH_MIN < t < t_table[0]`.
* The implementation requires that `t_table[0] >= dsps.constants.T_TABLE_MIN`.
* Note that `T_BIRTH_MIN=0.001 Gyr` corresponds to `z~600`, `T_TABLE_MIN=0.01 Gyr` corresponds to `z~140`, and `SFR_MIN=1e-14`, so these boundary conditions should not impact galaxy mass at any redshift of practical interest.

Cumulative trapezoidal integration is not implemented in `jax.numpy`, and so this PR brings in a new custom kernel for this computation, `dsps.utils.cumtrapz`, which is based on `lax.scan`.