### PR TITLE
Resolve DeprecationWarning from using np.trapz in CI tests

### DIFF
--- a/dsps/tests/test_utils.py
+++ b/dsps/tests/test_utils.py
@@ -1,6 +1,8 @@
 """
 """
+
 import numpy as np
+import pytest
 from jax import random as jran
 
 from ..constants import T_TABLE_MIN
@@ -20,6 +22,15 @@ from ..utils import (
     trapz,
     triweighted_histogram,
 )
+
+try:
+    from scipy.integrate import trapezoid
+
+    HAS_SCIPY = True
+except ImportError:
+    HAS_SCIPY = False
+
+MSG_HAS_SCIPY = "Must have scipy installed to run this test"
 
 
 def test_sigmoid_inversion():
@@ -159,6 +170,7 @@ def test_powerlaw_pdf():
     assert np.any(pdf > 0)
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason=MSG_HAS_SCIPY)
 def test_cumtrapz():
     ran_key = jran.PRNGKey(0)
     n_x = 100
@@ -168,11 +180,12 @@ def test_cumtrapz():
         xarr = np.sort(jran.uniform(x_key, minval=0, maxval=1, shape=(n_x,)))
         yarr = jran.uniform(y_key, minval=0, maxval=1, shape=(n_x,))
         jax_result = cumtrapz(xarr, yarr)
-        np_result = [np.trapz(yarr[:-i], x=xarr[:-i]) for i in range(1, n_x)][::-1]
+        np_result = [trapezoid(yarr[:-i], x=xarr[:-i]) for i in range(1, n_x)][::-1]
         assert np.allclose(jax_result[:-1], np_result, rtol=1e-4)
-        assert np.allclose(jax_result[-1], np.trapz(yarr, x=xarr), rtol=1e-4)
+        assert np.allclose(jax_result[-1], trapezoid(yarr, x=xarr), rtol=1e-4)
 
 
+@pytest.mark.skipif(not HAS_SCIPY, reason=MSG_HAS_SCIPY)
 def test_trapz():
     ran_key = jran.PRNGKey(0)
     n_x = 100
@@ -182,7 +195,7 @@ def test_trapz():
         xarr = np.sort(jran.uniform(x_key, minval=0, maxval=1, shape=(n_x,)))
         yarr = jran.uniform(y_key, minval=0, maxval=1, shape=(n_x,))
         jax_result = trapz(xarr, yarr)
-        np_result = np.trapz(yarr, x=xarr)
+        np_result = trapezoid(yarr, x=xarr)
         assert np.allclose(jax_result, np_result, rtol=1e-4)
 
 


### PR DESCRIPTION
Switch to scipy.integrate.trapezoid to avoid DeprecationWarning raised in unit testing. We have a cron workflow that treats warnings as errors. This PR resolves the recent failure of that cron.

This is also implemented in https://github.com/ArgonneCPAC/diffstar/pull/76.