### PR TITLE
Switch to double precision in SSP weights

### DIFF
--- a/dsps/sed/metallicity_weights.py
+++ b/dsps/sed/metallicity_weights.py
@@ -1,12 +1,19 @@
 """Kernels calculating metallicity PDF-weighting of SSP tempates"""
-from jax import numpy as jnp
-from jax import jit as jjit
-from jax import vmap
-from .stellar_age_weights import _get_lgt_birth
-from ..utils import triweighted_histogram, _get_bin_edges
-from ..utils import _fill_empty_weights_singlepoint
-from ..constants import LGMET_LO, LGMET_HI
 
+import jax
+from jax import jit as jjit
+from jax import numpy as jnp
+from jax import vmap
+
+from ..constants import LGMET_HI, LGMET_LO
+from ..utils import (
+    _fill_empty_weights_singlepoint,
+    _get_bin_edges,
+    triweighted_histogram,
+)
+from .stellar_age_weights import _get_lgt_birth
+
+jax.config.update("jax_enable_x64", True)
 
 __all__ = (
     "calc_lgmet_weights_from_lognormal_mdf",

--- a/dsps/sed/ssp_weights.py
+++ b/dsps/sed/ssp_weights.py
@@ -1,10 +1,18 @@
 """Kernels calculating SSP weights of a composite stellar population"""
+
 import typing
+
+import jax
 from jax import jit as jjit
 from jax import numpy as jnp
+
+from .metallicity_weights import (
+    calc_lgmet_weights_from_lgmet_table,
+    calc_lgmet_weights_from_lognormal_mdf,
+)
 from .stellar_age_weights import calc_age_weights_from_sfh_table
-from .metallicity_weights import calc_lgmet_weights_from_lognormal_mdf
-from .metallicity_weights import calc_lgmet_weights_from_lgmet_table
+
+jax.config.update("jax_enable_x64", True)
 
 __all__ = (
     "calc_ssp_weights_sfh_table_lognormal_mdf",

--- a/dsps/sed/stellar_age_weights.py
+++ b/dsps/sed/stellar_age_weights.py
@@ -1,10 +1,14 @@
 """Kernels calculating stellar age PDF-weighting of SSP tempates"""
+
+import jax
 from jax import jit as jjit
 from jax import numpy as jnp
 
 from ..constants import N_T_LGSM_INTEGRATION, SFR_MIN, T_BIRTH_MIN
 from ..cosmology import TODAY
 from ..utils import _jax_get_dt_array, cumulative_mstar_formed
+
+jax.config.update("jax_enable_x64", True)
 
 __all__ = ("calc_age_weights_from_sfh_table",)
 

--- a/dsps/sed/stellar_sed.py
+++ b/dsps/sed/stellar_sed.py
@@ -1,11 +1,19 @@
 """Functions calculating the SED of a composite stellar population"""
+
 import typing
+
+import jax
 from jax import jit as jjit
 from jax import numpy as jnp
-from .ssp_weights import calc_ssp_weights_sfh_table_lognormal_mdf
-from .ssp_weights import calc_ssp_weights_sfh_table_met_table
-from .stellar_age_weights import _calc_logsm_table_from_sfh_table
+
 from ..constants import SFR_MIN
+from .ssp_weights import (
+    calc_ssp_weights_sfh_table_lognormal_mdf,
+    calc_ssp_weights_sfh_table_met_table,
+)
+from .stellar_age_weights import _calc_logsm_table_from_sfh_table
+
+jax.config.update("jax_enable_x64", True)
 
 __all__ = ("calc_rest_sed_sfh_table_lognormal_mdf", "calc_rest_sed_sfh_table_met_table")
 


### PR DESCRIPTION
This PR resolves a lingering issue with noisy age weights at the young-star end of the stellar age PDF. This was first noted in https://github.com/ArgonneCPAC/dsps/pull/78, which improved the integration technique to use trapezoidal sums. But that PR showed the issue was not fully resolved by that fix. Based on the plots below (one plot is just a zoom-in of the other), the root cause seems to have been the use of single precision floats in the calculation of the age weights. I have verified that this has a minimal effect on broadband photometry, although it may be more important for emission line predictions.

![stellar_age_weights_single_vs_double_precision](https://github.com/user-attachments/assets/74259408-de80-46d4-859b-d5af6f2b8508)

![stellar_age_weights_single_vs_double_precision2](https://github.com/user-attachments/assets/50ab272d-8eb2-4a8a-8ad0-05c79d425922)
