### PR TITLE
Fix call to `jax.config.update("jax_enable_x64", True)`

### DIFF
--- a/dsps/dust/blackbody.py
+++ b/dsps/dust/blackbody.py
@@ -1,10 +1,12 @@
 """JAX implementation of a blackbody spectral energy density"""
-import numpy as np
+
 from jax import config
-from jax import jit as jjit
-from jax import lax
 
 config.update("jax_enable_x64", True)
+
+import numpy as np
+from jax import jit as jjit
+from jax import lax
 
 H_PLANCK = 6.62607015e-34  # J*s
 K_BOLTZ = 1.380649e-23  # J/K

--- a/dsps/sed/__init__.py
+++ b/dsps/sed/__init__.py
@@ -1,7 +1,10 @@
 # flake8: noqa
-"""
-"""
+""" """
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
 from .metallicity_weights import *
-from .stellar_age_weights import *
 from .ssp_weights import *
+from .stellar_age_weights import *
 from .stellar_sed import *

--- a/dsps/sed/metallicity_weights.py
+++ b/dsps/sed/metallicity_weights.py
@@ -1,6 +1,9 @@
 """Kernels calculating metallicity PDF-weighting of SSP tempates"""
 
 import jax
+
+jax.config.update("jax_enable_x64", True)
+
 from jax import jit as jjit
 from jax import numpy as jnp
 from jax import vmap
@@ -12,8 +15,6 @@ from ..utils import (
     triweighted_histogram,
 )
 from .stellar_age_weights import _get_lgt_birth
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = (
     "calc_lgmet_weights_from_lognormal_mdf",

--- a/dsps/sed/ssp_weights.py
+++ b/dsps/sed/ssp_weights.py
@@ -1,8 +1,11 @@
 """Kernels calculating SSP weights of a composite stellar population"""
 
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
 import typing
 
-import jax
 from jax import jit as jjit
 from jax import numpy as jnp
 
@@ -11,8 +14,6 @@ from .metallicity_weights import (
     calc_lgmet_weights_from_lognormal_mdf,
 )
 from .stellar_age_weights import calc_age_weights_from_sfh_table
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = (
     "calc_ssp_weights_sfh_table_lognormal_mdf",

--- a/dsps/sed/stellar_age_weights.py
+++ b/dsps/sed/stellar_age_weights.py
@@ -1,14 +1,15 @@
 """Kernels calculating stellar age PDF-weighting of SSP tempates"""
 
 import jax
+
+jax.config.update("jax_enable_x64", True)
+
 from jax import jit as jjit
 from jax import numpy as jnp
 
 from ..constants import N_T_LGSM_INTEGRATION, SFR_MIN, T_BIRTH_MIN
 from ..cosmology import TODAY
 from ..utils import _jax_get_dt_array, cumulative_mstar_formed
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ("calc_age_weights_from_sfh_table",)
 

--- a/dsps/sed/stellar_sed.py
+++ b/dsps/sed/stellar_sed.py
@@ -1,8 +1,11 @@
 """Functions calculating the SED of a composite stellar population"""
 
+import jax
+
+jax.config.update("jax_enable_x64", True)
+
 import typing
 
-import jax
 from jax import jit as jjit
 from jax import numpy as jnp
 
@@ -12,8 +15,6 @@ from .ssp_weights import (
     calc_ssp_weights_sfh_table_met_table,
 )
 from .stellar_age_weights import _calc_logsm_table_from_sfh_table
-
-jax.config.update("jax_enable_x64", True)
 
 __all__ = ("calc_rest_sed_sfh_table_lognormal_mdf", "calc_rest_sed_sfh_table_met_table")
 


### PR DESCRIPTION
Using double precision needs to happen at the very top of the module, not below other jax imports. This was not done correctly in #107. 