### PR TITLE
Add new convenience function `get_subset_emline_data`

### DIFF
--- a/dsps/data_loaders/load_emline_info.py
+++ b/dsps/data_loaders/load_emline_info.py
@@ -1,5 +1,7 @@
 """"""
 
+from collections import namedtuple
+
 import numpy as np
 
 
@@ -23,3 +25,36 @@ def read_emlines_info_fsps(fn, testmode=False):
         return emline_dict, line_wave_arr
     else:
         return emline_dict
+
+
+def get_subset_emline_data(ssp_data, emline_names):
+    """Construct a new ssp_data based only a subset of the emission lines
+
+    Parameters
+    ----------
+    ssp_data : namedtuple
+
+    emline_names : list of strings
+        Each entry should appear in ssp_data.ssp_emline_wave._fields
+
+    Returns
+    -------
+    ssp_data : namedtuple
+        The ssp_emline_wave and ssp_emline_luminosity fields will be replaced
+        with only information about lines in emline_names, preserving order.
+
+    """
+    indx_lines = np.array(
+        [ssp_data.ssp_emline_wave._fields.index(name) for name in emline_names]
+    )
+    line_wave = np.array(ssp_data.ssp_emline_wave)[indx_lines]
+    EmLineWave = namedtuple("EmLineWave", emline_names)
+    line_wave = EmLineWave(*line_wave)
+
+    line_lum = ssp_data.ssp_emline_luminosity[:, :, indx_lines]
+
+    ssp_data = ssp_data._replace(
+        ssp_emline_wave=line_wave, ssp_emline_luminosity=line_lum
+    )
+
+    return ssp_data

--- a/dsps/data_loaders/load_emline_info.py
+++ b/dsps/data_loaders/load_emline_info.py
@@ -1,0 +1,25 @@
+""""""
+
+import numpy as np
+
+
+def read_emlines_info_fsps(fn, testmode=False):
+    """Read the FSPS file emlines_info.dat into a dictionary"""
+    line_wave_collector = []
+    emline_dict = dict()
+    with open(fn, "r") as f:
+        for raw_line in f:
+            line = raw_line.strip()
+            _line_wave, _a = line.split(",")
+            line_wave = float(_line_wave)
+            _b = _a.replace("-", "_").replace(" ", "_").replace(".", "p")
+            line_name = _b.replace("[", "").replace("]", "")
+
+            emline_dict[line_name] = line_wave
+            line_wave_collector.append(line_wave)
+
+    if testmode:
+        line_wave_arr = np.array(line_wave_collector)
+        return emline_dict, line_wave_arr
+    else:
+        return emline_dict

--- a/dsps/data_loaders/tests/test_load_emline_info.py
+++ b/dsps/data_loaders/tests/test_load_emline_info.py
@@ -1,0 +1,38 @@
+""""""
+
+from importlib.resources import files
+
+import numpy as np
+
+from .. import load_emline_info as lemi
+from ..load_ssp_data import load_ssp_templates
+
+EMLINES_INFO_BNAME = "emlines_info.dat"
+
+
+def test_read_emlines_info_fsps_returns_something():
+    fn = files("dsps").joinpath("data", EMLINES_INFO_BNAME)
+    emline_dict, line_wave_arr = lemi.read_emlines_info_fsps(fn, testmode=True)
+    assert np.allclose(np.array(list(emline_dict.values())), line_wave_arr, rtol=1e-3)
+
+
+def test_read_emlines_info_fsps_field_names():
+    ssp_data = load_ssp_templates(
+        bn="fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5"
+    )
+    fn = files("dsps").joinpath("data", EMLINES_INFO_BNAME)
+    emline_dict, line_wave_arr = lemi.read_emlines_info_fsps(fn, testmode=True)
+
+    seq = [x != y for x, y in zip(emline_dict.keys(), ssp_data.ssp_emline_wave._fields)]
+    n_disagree = sum(seq)
+    assert n_disagree == 0
+
+
+def test_read_emlines_info_fsps_line_wave_values():
+    ssp_data = load_ssp_templates(
+        bn="fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5"
+    )
+    fn = files("dsps").joinpath("data", EMLINES_INFO_BNAME)
+    emline_dict, line_wave_arr = lemi.read_emlines_info_fsps(fn, testmode=True)
+
+    assert np.allclose(ssp_data.ssp_emline_wave, line_wave_arr, rtol=1e-3)

--- a/dsps/data_loaders/tests/test_load_emline_info.py
+++ b/dsps/data_loaders/tests/test_load_emline_info.py
@@ -36,3 +36,34 @@ def test_read_emlines_info_fsps_line_wave_values():
     emline_dict, line_wave_arr = lemi.read_emlines_info_fsps(fn, testmode=True)
 
     assert np.allclose(ssp_data.ssp_emline_wave, line_wave_arr, rtol=1e-3)
+
+
+def test_get_subset_emline_data_agrees_with_full_data():
+    """Enforce that the ssp_data subset agrees with the original data"""
+    ssp_data = load_ssp_templates(
+        bn="fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5"
+    )
+
+    indx_sel = [3, 5, 7]
+    line_names = ssp_data.ssp_emline_wave._fields
+    emline_names = [line_names[i] for i in indx_sel]
+    # emline_names = ["Ly_5_937", "Ly_gamma_972", "He_II_1084p94A"]
+
+    ssp_data_new = lemi.get_subset_emline_data(ssp_data, emline_names)
+
+    for i_new, i_orig in enumerate(indx_sel):
+        assert np.allclose(
+            ssp_data_new.ssp_emline_wave[i_new], ssp_data.ssp_emline_wave[i_orig]
+        )
+
+    for name in emline_names:
+        assert np.allclose(
+            getattr(ssp_data_new.ssp_emline_wave, name),
+            getattr(ssp_data.ssp_emline_wave, name),
+        )
+
+    for i_new, i_orig in enumerate(indx_sel):
+        assert np.allclose(
+            ssp_data_new.ssp_emline_luminosity[:, :, i_new],
+            ssp_data.ssp_emline_luminosity[:, :, i_orig],
+        )


### PR DESCRIPTION
The new function `get_subset_emline_data` constructs a new, smaller `ssp_data` object from the larger one, selecting only a subset of the lines to define the fields `ssp_emline_wave` and `ssp_emline_luminosity`.