### PR TITLE
Add `n_lines=0` feature to `load_fake_ssp_data` function

### DIFF
--- a/dsps/data_loaders/retrieve_fake_fsps_data.py
+++ b/dsps/data_loaders/retrieve_fake_fsps_data.py
@@ -45,8 +45,12 @@ def load_fake_ssp_data(n_line=166):
     ssp_lg_age_gyr = _get_log_age_gyr()
     ssp_wave = _get_ssp_wave()
     ssp_flux = _get_spec_ssp()
-    ssp_emline_wave = _get_emline_wave_namedtuple(n_line)
-    ssp_emline_luminosity = _get_ssp_emline_luminosity(n_line)
+    if n_line == 0:
+        ssp_emline_wave = None
+        ssp_emline_luminosity = None
+    else:
+        ssp_emline_wave = _get_emline_wave_namedtuple(n_line)
+        ssp_emline_luminosity = _get_ssp_emline_luminosity(n_line)
 
     return SSPData(
         ssp_lgmet,

--- a/dsps/data_loaders/tests/test_retrieve_fake_fsps_data.py
+++ b/dsps/data_loaders/tests/test_retrieve_fake_fsps_data.py
@@ -31,6 +31,16 @@ def test_load_fake_ssp_data():
     assert np.any(np.array(ssp_data.ssp_emline_luminosity) > 1e20)
 
 
+def test_load_fake_ssp_data_nolines():
+    ssp_data = load_fake_ssp_data(n_line=0)
+    assert ssp_data.ssp_emline_wave is None
+    assert ssp_data.ssp_emline_luminosity is None
+
+    ssp_data = load_fake_ssp_data(n_line=1)
+    assert ssp_data.ssp_emline_wave is not None
+    assert ssp_data.ssp_emline_luminosity is not None
+
+
 def test_load_fake_filter_transmission_curves():
     _res = load_fake_filter_transmission_curves()
 


### PR DESCRIPTION
This feature is useful for backwards compatibility of downstream applications