### PR TITLE
Replace custom `dsps.utils.trapz` with `jnp.trapz`

### DIFF
--- a/dsps/utils.py
+++ b/dsps/utils.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 from jax import jit as jjit
 from jax import lax, nn
@@ -291,10 +290,7 @@ def trapz(xarr, yarr):
     result : float
 
     """
-    res_init = xarr[0], yarr[0], 0.0
-    scan_data = xarr, yarr
-    cumtrapz = scan(_cumtrapz_scan_func, res_init, scan_data)[1]
-    return cumtrapz[-1]
+    return jnp.trapezoid(yarr, xarr)
 
 
 @jjit


### PR DESCRIPTION
The function `dsps.utils.trapz` was originally written before JAX implemented `jnp.trapezoid`. The custom version in DSPS is based on a `lax.scan`. This PR replaces the custom implementation with `jax.numpy.trapezoid`.

Note that there does not exist a corresponding `jax.numpy` implementation of the custom `dsps.utils.cumtrapz` function. According to jakevdp in https://github.com/jax-ml/jax/issues/22651, there are no plans to implement this in JAX.

Closes #125. 