### PR TITLE
Add MZR_PBOUNDS namedtuple.

### DIFF
--- a/dsps/metallicity/tests/test_umzr.py
+++ b/dsps/metallicity/tests/test_umzr.py
@@ -1,5 +1,4 @@
-"""
-"""
+""" """
 
 import numpy as np
 from jax import random as jran
@@ -101,3 +100,14 @@ def test_default_umzr_params():
     gen = zip(umzr.DEFAULT_MZR_U_PARAMS, umzr.DEFAULT_MZR_U_PARAMS._fields)
     for u_param, key in gen:
         assert np.all(np.isfinite(u_param)), f"Parameter `{key}` is NaN"
+
+
+def test_default_values_within_bounds():
+    values = umzr.DEFAULT_MZR_PARAMS._asdict()
+    bounds = umzr.MZR_PBOUNDS._asdict()
+
+    assert len(values) == len(bounds)
+
+    for param_name, val in values.items():
+        low, high = bounds[param_name]
+        assert low <= val <= high

--- a/dsps/metallicity/umzr.py
+++ b/dsps/metallicity/umzr.py
@@ -1,5 +1,4 @@
-"""Mass-metallicity-redshift scaling relation with unbounding behavior
-"""
+"""Mass-metallicity-redshift scaling relation with unbounding behavior"""
 
 from collections import OrderedDict, namedtuple
 

--- a/dsps/metallicity/umzr.py
+++ b/dsps/metallicity/umzr.py
@@ -67,7 +67,7 @@ MZRParams = namedtuple("MZRParams", _MZR_PNAMES)
 MZRUParams = namedtuple("MZRUParams", _MZR_UPNAMES)
 
 DEFAULT_MZR_PARAMS = MZRParams(**DEFAULT_MZR_PDICT)
-BOUNDS_MZR_PARAMS = MZRParams(**MZR_PBDICT)
+MZR_PBOUNDS = MZRParams(**MZR_PBDICT)
 
 
 def get_ran_t0_params(ran_key, bounds_pdict=MZR_T0_PBDICT):

--- a/dsps/metallicity/umzr.py
+++ b/dsps/metallicity/umzr.py
@@ -67,6 +67,7 @@ MZRParams = namedtuple("MZRParams", _MZR_PNAMES)
 MZRUParams = namedtuple("MZRUParams", _MZR_UPNAMES)
 
 DEFAULT_MZR_PARAMS = MZRParams(**DEFAULT_MZR_PDICT)
+BOUNDS_MZR_PARAMS = MZRParams(**MZR_PBDICT)
 
 
 def get_ran_t0_params(ran_key, bounds_pdict=MZR_T0_PBDICT):


### PR DESCRIPTION
This PR includes a new namedtuple `MZR_PBOUNDS` that can be imported from `dsps.metallicity.umzr.py`.
It has the same structure as `DEFAULT_MZR_PARAMS`, but instead of storing the default scalar values, it stores tuples containing the lower and upper bounds for each parameter.
This is similar to this [PR in diffstar](https://github.com/ArgonneCPAC/diffstar/pull/117).