### PR TITLE
Require astropy>=7 with numpy>=2 to resolve CI fail

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.11
+          python-version: 3.12
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true

--- a/.github/workflows/monthly-warning-test.yaml
+++ b/.github/workflows/monthly-warning-test.yaml
@@ -5,10 +5,6 @@ on:
   schedule:
     # Runs "First of every month at 3:15am Central"
     - cron: '15 8 1 * *'
-  push:
-    branches:
-      - main
-  pull_request: null
 
 jobs:
   tests:

--- a/.github/workflows/monthly-warning-test.yaml
+++ b/.github/workflows/monthly-warning-test.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
     # Runs "First of every month at 3:15am Central"
     - cron: '15 8 1 * *'
+  push:
+    branches:
+      - main
+  pull_request: null
 
 jobs:
   tests:
@@ -18,7 +22,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.11
+          python-version: 3.12
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true

--- a/.github/workflows/monthly-warning-test.yaml
+++ b/.github/workflows/monthly-warning-test.yaml
@@ -50,18 +50,22 @@ jobs:
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: download dsps data
+        timeout-minutes: 5
+
         shell: bash -l {0}
         run: |
+          WGET_OPTS="-4 --tries=3 --timeout=30 --waitretry=5 --retry-connrefused"
+
           # Create data directory
           mkdir -p dsps_drn/filters
 
           # Download data
           cd dsps_drn
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_lgmet_age.h5
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_lgmet_age.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5
           cd filters
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
 
           # Set environment variable
           export DSPS_DRN="${GITHUB_WORKSPACE}/dsps_drn"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,7 +36,6 @@ jobs:
             --file=requirements.txt
           conda install -y -q \
             matplotlib \
-            astropy>=7 \
             flake8 \
             pytest \
             pytest-xdist \

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,18 +49,21 @@ jobs:
           python -m pip install --no-build-isolation --no-deps -e .
 
       - name: download dsps data
+        timeout-minutes: 5
         shell: bash -l {0}
         run: |
+          WGET_OPTS="-4 --tries=3 --timeout=30 --waitretry=5 --retry-connrefused"
+
           # Create data directory
           mkdir -p dsps_drn/filters
 
           # Download data
           cd dsps_drn
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_lgmet_age.h5
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/ssp_data_fsps_v3.2_lgmet_age.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/fsps_v0.4.7_mist_c3k_a_kroupa_wNE_logGasU-2.0_logGasZ0.0.h5
           cd filters
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
-          wget https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_u_transmission.h5
+          wget $WGET_OPTS https://portal.nersc.gov/project/hacc/aphearin/DSPS_data/filters/lsst_g_transmission.h5
 
           # Set environment variable
           export DSPS_DRN="${GITHUB_WORKSPACE}/dsps_drn"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.11
+          python-version: 3.12
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
@@ -36,7 +36,7 @@ jobs:
             --file=requirements.txt
           conda install -y -q \
             matplotlib \
-            astropy \
+            astropy>=7 \
             flake8 \
             pytest \
             pytest-xdist \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy>=2
 jax
 h5py


### PR DESCRIPTION
[This CI job fail ](https://github.com/ArgonneCPAC/dsps/actions/runs/27129520843/job/80066633931) indicates we need to have a version of astropy that's compatible with `numpy>=2`